### PR TITLE
Share parser fix

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--  Nextcloud Android Library is available under MIT license
-   Copyright (C) 2015 ownCloud Inc.
+   Copyright (C) 2016 ownCloud GmbH.
     
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -3,7 +3,7 @@
 ownCloud Android Library is available under MIT license
 
 Copyright (C) 2016 Nextcloud Project
-Copyright (C) 2014-2016 ownCloud Inc.
+Copyright (C) 2014-2016 ownCloud GmbH.
 Copyright (C) 2012 Bartek Przybylski
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/res/values/empty.xml
+++ b/res/values/empty.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--  ownCloud Android Library is available under MIT license
-   Copyright (C) 2015 ownCloud Inc.
+   Copyright (C) 2016 ownCloud GmbH.
     
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal

--- a/sample_client/AndroidManifest.xml
+++ b/sample_client/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--  ownCloud Android Library is available under MIT license
-   Copyright (C) 2015 ownCloud Inc.
+   Copyright (C) 2016 ownCloud GmbH.
     
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal

--- a/sample_client/res/layout/file_in_list.xml
+++ b/sample_client/res/layout/file_in_list.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--  ownCloud Android Library is available under MIT license
-   Copyright (C) 2015 ownCloud Inc.
+   Copyright (C) 2016 ownCloud GmbH.
     
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal

--- a/sample_client/res/layout/main.xml
+++ b/sample_client/res/layout/main.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--  ownCloud Android Library is available under MIT license
-   Copyright (C) 2015 ownCloud Inc.
+   Copyright (C) 2016 ownCloud GmbH.
     
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal

--- a/sample_client/res/values-v11/styles.xml
+++ b/sample_client/res/values-v11/styles.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--  ownCloud Android Library is available under MIT license
-   Copyright (C) 2015 ownCloud Inc.
+   Copyright (C) 2016 ownCloud GmbH.
     
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal

--- a/sample_client/res/values/dimensions.xml
+++ b/sample_client/res/values/dimensions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--  ownCloud Android Library is available under MIT license
-   Copyright (C) 2015 ownCloud Inc.
+   Copyright (C) 2016 ownCloud GmbH.
     
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal

--- a/sample_client/res/values/setup.xml
+++ b/sample_client/res/values/setup.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--  ownCloud Android Library is available under MIT license
-   Copyright (C) 2015 ownCloud Inc.
+   Copyright (C) 2016 ownCloud GmbH.
     
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal

--- a/sample_client/res/values/strings.xml
+++ b/sample_client/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--  ownCloud Android Library is available under MIT license
-   Copyright (C) 2015 ownCloud Inc.
+   Copyright (C) 2016 ownCloud GmbH.
     
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal

--- a/sample_client/res/values/styles.xml
+++ b/sample_client/res/values/styles.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--  ownCloud Android Library is available under MIT license
-   Copyright (C) 2015 ownCloud Inc.
+   Copyright (C) 2016 ownCloud GmbH.
     
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal

--- a/sample_client/src/com/owncloud/android/lib/sampleclient/FilesArrayAdapter.java
+++ b/sample_client/src/com/owncloud/android/lib/sampleclient/FilesArrayAdapter.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/sample_client/src/com/owncloud/android/lib/sampleclient/MainActivity.java
+++ b/sample_client/src/com/owncloud/android/lib/sampleclient/MainActivity.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/common/OwnCloudAccount.java
+++ b/src/com/owncloud/android/lib/common/OwnCloudAccount.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/common/OwnCloudBasicCredentials.java
+++ b/src/com/owncloud/android/lib/common/OwnCloudBasicCredentials.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/common/OwnCloudBearerCredentials.java
+++ b/src/com/owncloud/android/lib/common/OwnCloudBearerCredentials.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/common/OwnCloudClient.java
+++ b/src/com/owncloud/android/lib/common/OwnCloudClient.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   Copyright (C) 2012  Bartek Przybylski
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/com/owncloud/android/lib/common/OwnCloudClientFactory.java
+++ b/src/com/owncloud/android/lib/common/OwnCloudClientFactory.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/common/OwnCloudClientManager.java
+++ b/src/com/owncloud/android/lib/common/OwnCloudClientManager.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/common/OwnCloudClientManagerFactory.java
+++ b/src/com/owncloud/android/lib/common/OwnCloudClientManagerFactory.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/common/OwnCloudCredentials.java
+++ b/src/com/owncloud/android/lib/common/OwnCloudCredentials.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/common/OwnCloudCredentialsFactory.java
+++ b/src/com/owncloud/android/lib/common/OwnCloudCredentialsFactory.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/common/OwnCloudSamlSsoCredentials.java
+++ b/src/com/owncloud/android/lib/common/OwnCloudSamlSsoCredentials.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/common/SimpleFactoryManager.java
+++ b/src/com/owncloud/android/lib/common/SimpleFactoryManager.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/common/SingleSessionManager.java
+++ b/src/com/owncloud/android/lib/common/SingleSessionManager.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/common/accounts/AccountTypeUtils.java
+++ b/src/com/owncloud/android/lib/common/accounts/AccountTypeUtils.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/common/accounts/AccountUtils.java
+++ b/src/com/owncloud/android/lib/common/accounts/AccountUtils.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   Copyright (C) 2012  Bartek Przybylski
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/com/owncloud/android/lib/common/network/AdvancedSslSocketFactory.java
+++ b/src/com/owncloud/android/lib/common/network/AdvancedSslSocketFactory.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/common/network/AdvancedX509TrustManager.java
+++ b/src/com/owncloud/android/lib/common/network/AdvancedX509TrustManager.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/common/network/BearerAuthScheme.java
+++ b/src/com/owncloud/android/lib/common/network/BearerAuthScheme.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/common/network/BearerCredentials.java
+++ b/src/com/owncloud/android/lib/common/network/BearerCredentials.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/common/network/CertificateCombinedException.java
+++ b/src/com/owncloud/android/lib/common/network/CertificateCombinedException.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/common/network/ChunkFromFileChannelRequestEntity.java
+++ b/src/com/owncloud/android/lib/common/network/ChunkFromFileChannelRequestEntity.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/common/network/FileRequestEntity.java
+++ b/src/com/owncloud/android/lib/common/network/FileRequestEntity.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   Copyright (C) 2012  Bartek Przybylski
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/com/owncloud/android/lib/common/network/NetworkUtils.java
+++ b/src/com/owncloud/android/lib/common/network/NetworkUtils.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/common/network/OnDatatransferProgressListener.java
+++ b/src/com/owncloud/android/lib/common/network/OnDatatransferProgressListener.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   Copyright (C) 2012  Bartek Przybylski
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/com/owncloud/android/lib/common/network/ProgressiveDataTransferer.java
+++ b/src/com/owncloud/android/lib/common/network/ProgressiveDataTransferer.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/common/network/RedirectionPath.java
+++ b/src/com/owncloud/android/lib/common/network/RedirectionPath.java
@@ -2,7 +2,7 @@
  *
  *   @author David A. Velasco
  *
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/common/network/ServerNameIndicator.java
+++ b/src/com/owncloud/android/lib/common/network/ServerNameIndicator.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/common/network/WebdavEntry.java
+++ b/src/com/owncloud/android/lib/common/network/WebdavEntry.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/common/network/WebdavUtils.java
+++ b/src/com/owncloud/android/lib/common/network/WebdavUtils.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   Copyright (C) 2012 Bartek Przybylski
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/com/owncloud/android/lib/common/operations/InvalidCharacterExceptionParser.java
+++ b/src/com/owncloud/android/lib/common/operations/InvalidCharacterExceptionParser.java
@@ -1,6 +1,6 @@
 
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/common/operations/OnRemoteOperationListener.java
+++ b/src/com/owncloud/android/lib/common/operations/OnRemoteOperationListener.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/common/operations/OperationCancelledException.java
+++ b/src/com/owncloud/android/lib/common/operations/OperationCancelledException.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/common/operations/RemoteOperation.java
+++ b/src/com/owncloud/android/lib/common/operations/RemoteOperation.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/common/operations/RemoteOperationResult.java
+++ b/src/com/owncloud/android/lib/common/operations/RemoteOperationResult.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/resources/files/ChunkedUploadRemoteFileOperation.java
+++ b/src/com/owncloud/android/lib/resources/files/ChunkedUploadRemoteFileOperation.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/resources/files/CopyRemoteFileOperation.java
+++ b/src/com/owncloud/android/lib/resources/files/CopyRemoteFileOperation.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2014 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/resources/files/CreateRemoteFolderOperation.java
+++ b/src/com/owncloud/android/lib/resources/files/CreateRemoteFolderOperation.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/resources/files/DownloadRemoteFileOperation.java
+++ b/src/com/owncloud/android/lib/resources/files/DownloadRemoteFileOperation.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/resources/files/ExistenceCheckRemoteOperation.java
+++ b/src/com/owncloud/android/lib/resources/files/ExistenceCheckRemoteOperation.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/resources/files/FileUtils.java
+++ b/src/com/owncloud/android/lib/resources/files/FileUtils.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/resources/files/MoveRemoteFileOperation.java
+++ b/src/com/owncloud/android/lib/resources/files/MoveRemoteFileOperation.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/resources/files/ReadRemoteFileOperation.java
+++ b/src/com/owncloud/android/lib/resources/files/ReadRemoteFileOperation.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/resources/files/ReadRemoteFolderOperation.java
+++ b/src/com/owncloud/android/lib/resources/files/ReadRemoteFolderOperation.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/resources/files/RemoteFile.java
+++ b/src/com/owncloud/android/lib/resources/files/RemoteFile.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/resources/files/RemoveRemoteFileOperation.java
+++ b/src/com/owncloud/android/lib/resources/files/RemoveRemoteFileOperation.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/resources/files/RenameRemoteFileOperation.java
+++ b/src/com/owncloud/android/lib/resources/files/RenameRemoteFileOperation.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/resources/files/UploadRemoteFileOperation.java
+++ b/src/com/owncloud/android/lib/resources/files/UploadRemoteFileOperation.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/resources/shares/CreateRemoteShareOperation.java
+++ b/src/com/owncloud/android/lib/resources/shares/CreateRemoteShareOperation.java
@@ -1,7 +1,7 @@
 /* ownCloud Android Library is available under MIT license
  *   @author masensio
  *   @author David A. Velasco
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/resources/shares/GetRemoteShareOperation.java
+++ b/src/com/owncloud/android/lib/resources/shares/GetRemoteShareOperation.java
@@ -1,6 +1,6 @@
 /* ownCloud Android Library is available under MIT license
  *   @author David A. Velasco
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/resources/shares/GetRemoteShareesOperation.java
+++ b/src/com/owncloud/android/lib/resources/shares/GetRemoteShareesOperation.java
@@ -2,7 +2,7 @@
  *
  *   @author masensio
  *   @author David A. Velasco
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/resources/shares/GetRemoteSharesForFileOperation.java
+++ b/src/com/owncloud/android/lib/resources/shares/GetRemoteSharesForFileOperation.java
@@ -1,7 +1,7 @@
 /* ownCloud Android Library is available under MIT license
  *   @author masensio
  *   @author David A. Velasco
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/resources/shares/GetRemoteSharesOperation.java
+++ b/src/com/owncloud/android/lib/resources/shares/GetRemoteSharesOperation.java
@@ -1,7 +1,7 @@
 /* ownCloud Android Library is available under MIT license
  *   @author masensio
  *   @author David A. Velasco
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/resources/shares/OCShare.java
+++ b/src/com/owncloud/android/lib/resources/shares/OCShare.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/resources/shares/RemoveRemoteShareOperation.java
+++ b/src/com/owncloud/android/lib/resources/shares/RemoveRemoteShareOperation.java
@@ -1,7 +1,7 @@
 /* ownCloud Android Library is available under MIT license
  *   @author masensio
  *   @author David A. Velasco
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/resources/shares/SharePermissionsBuilder.java
+++ b/src/com/owncloud/android/lib/resources/shares/SharePermissionsBuilder.java
@@ -1,6 +1,6 @@
 /* ownCloud Android Library is available under MIT license
  *   @author David A. Velasco
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/resources/shares/ShareToRemoteOperationResultParser.java
+++ b/src/com/owncloud/android/lib/resources/shares/ShareToRemoteOperationResultParser.java
@@ -1,6 +1,6 @@
 /* ownCloud Android Library is available under MIT license
  *   @author David A. Velasco
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/resources/shares/ShareType.java
+++ b/src/com/owncloud/android/lib/resources/shares/ShareType.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/resources/shares/ShareUtils.java
+++ b/src/com/owncloud/android/lib/resources/shares/ShareUtils.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/resources/shares/ShareXMLParser.java
+++ b/src/com/owncloud/android/lib/resources/shares/ShareXMLParser.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/resources/shares/ShareXMLParser.java
+++ b/src/com/owncloud/android/lib/resources/shares/ShareXMLParser.java
@@ -353,7 +353,6 @@ public class ShareXMLParser {
 				share.setSharedWithDisplayName(readNode(parser, NODE_SHARE_WITH_DISPLAY_NAME));
 
 			} else if (name.equalsIgnoreCase(NODE_URL)) {
-				share.setShareType(ShareType.PUBLIC_LINK);
 				String value = readNode(parser, NODE_URL);
 				share.setShareLink(value);
 

--- a/src/com/owncloud/android/lib/resources/shares/UpdateRemoteShareOperation.java
+++ b/src/com/owncloud/android/lib/resources/shares/UpdateRemoteShareOperation.java
@@ -1,6 +1,6 @@
 /* ownCloud Android Library is available under MIT license
  *   @author David A. Velasco
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/resources/status/CapabilityBooleanType.java
+++ b/src/com/owncloud/android/lib/resources/status/CapabilityBooleanType.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   @author masensio
  *
  *   Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/com/owncloud/android/lib/resources/status/GetRemoteCapabilitiesOperation.java
+++ b/src/com/owncloud/android/lib/resources/status/GetRemoteCapabilitiesOperation.java
@@ -1,6 +1,6 @@
 /* ownCloud Android Library is available under MIT license
  *   @author masensio
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/resources/status/GetRemoteStatusOperation.java
+++ b/src/com/owncloud/android/lib/resources/status/GetRemoteStatusOperation.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/resources/status/OCCapability.java
+++ b/src/com/owncloud/android/lib/resources/status/OCCapability.java
@@ -1,6 +1,6 @@
 /* ownCloud Android Library is available under MIT license
  *   @author masensio
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/src/com/owncloud/android/lib/resources/status/OwnCloudVersion.java
+++ b/src/com/owncloud/android/lib/resources/status/OwnCloudVersion.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   Copyright (C) 2012  Bartek Przybylski
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/com/owncloud/android/lib/resources/users/GetRemoteUserInfoOperation.java
+++ b/src/com/owncloud/android/lib/resources/users/GetRemoteUserInfoOperation.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/test_client/AndroidManifest.xml
+++ b/test_client/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--  ownCloud Android Library is available under MIT license
-   Copyright (C) 2015 ownCloud Inc.
+   Copyright (C) 2016 ownCloud GmbH.
     
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal

--- a/test_client/res/layout/activity_test.xml
+++ b/test_client/res/layout/activity_test.xml
@@ -1,5 +1,5 @@
 <!--  ownCloud Android Library is available under MIT license
-   Copyright (C) 2015 ownCloud Inc.
+   Copyright (C) 2016 ownCloud GmbH.
     
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal

--- a/test_client/res/menu/test.xml
+++ b/test_client/res/menu/test.xml
@@ -1,5 +1,5 @@
 <!--  ownCloud Android Library is available under MIT license
-   Copyright (C) 2015 ownCloud Inc.
+   Copyright (C) 2016 ownCloud GmbH.
     
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal

--- a/test_client/res/values-sw600dp/dimens.xml
+++ b/test_client/res/values-sw600dp/dimens.xml
@@ -1,5 +1,5 @@
 <!--  ownCloud Android Library is available under MIT license
-   Copyright (C) 2015 ownCloud Inc.
+   Copyright (C) 2016 ownCloud GmbH.
     
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal

--- a/test_client/res/values-sw720dp-land/dimens.xml
+++ b/test_client/res/values-sw720dp-land/dimens.xml
@@ -1,5 +1,5 @@
 <!--  ownCloud Android Library is available under MIT license
-   Copyright (C) 2015 ownCloud Inc.
+   Copyright (C) 2016 ownCloud GmbH.
     
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal

--- a/test_client/res/values-v11/styles.xml
+++ b/test_client/res/values-v11/styles.xml
@@ -1,5 +1,5 @@
 <!--  ownCloud Android Library is available under MIT license
-   Copyright (C) 2015 ownCloud Inc.
+   Copyright (C) 2016 ownCloud GmbH.
     
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal

--- a/test_client/res/values-v14/styles.xml
+++ b/test_client/res/values-v14/styles.xml
@@ -1,5 +1,5 @@
 <!--  ownCloud Android Library is available under MIT license
-   Copyright (C) 2015 ownCloud Inc.
+   Copyright (C) 2016 ownCloud GmbH.
     
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal

--- a/test_client/res/values/dimens.xml
+++ b/test_client/res/values/dimens.xml
@@ -1,5 +1,5 @@
 <!--  ownCloud Android Library is available under MIT license
-   Copyright (C) 2015 ownCloud Inc.
+   Copyright (C) 2016 ownCloud GmbH.
     
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal

--- a/test_client/res/values/setup.xml
+++ b/test_client/res/values/setup.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--  ownCloud Android Library is available under MIT license
-   Copyright (C) 2015 ownCloud Inc.
+   Copyright (C) 2016 ownCloud GmbH.
     
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal

--- a/test_client/res/values/strings.xml
+++ b/test_client/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--  ownCloud Android Library is available under MIT license
-   Copyright (C) 2015 ownCloud Inc.
+   Copyright (C) 2016 ownCloud GmbH.
     
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal

--- a/test_client/res/values/styles.xml
+++ b/test_client/res/values/styles.xml
@@ -1,5 +1,5 @@
 <!--  ownCloud Android Library is available under MIT license
-   Copyright (C) 2015 ownCloud Inc.
+   Copyright (C) 2016 ownCloud GmbH.
     
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal

--- a/test_client/src/com/owncloud/android/lib/test_project/SelfSignedConfidentSslSocketFactory.java
+++ b/test_client/src/com/owncloud/android/lib/test_project/SelfSignedConfidentSslSocketFactory.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/test_client/src/com/owncloud/android/lib/test_project/TestActivity.java
+++ b/test_client/src/com/owncloud/android/lib/test_project/TestActivity.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/test_client/tests/AndroidManifest.xml
+++ b/test_client/tests/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--  ownCloud Android Library is available under MIT license
-   Copyright (C) 2015 ownCloud Inc.
+   Copyright (C) 2016 ownCloud GmbH.
     
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal

--- a/test_client/tests/res/values/strings.xml
+++ b/test_client/tests/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--  ownCloud Android Library is available under MIT license
-   Copyright (C) 2015 ownCloud Inc.
+   Copyright (C) 2016 ownCloud GmbH.
     
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal

--- a/test_client/tests/src/com/owncloud/android/lib/test_project/test/CopyFileTest.java
+++ b/test_client/tests/src/com/owncloud/android/lib/test_project/test/CopyFileTest.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2014 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/test_client/tests/src/com/owncloud/android/lib/test_project/test/CreateFolderTest.java
+++ b/test_client/tests/src/com/owncloud/android/lib/test_project/test/CreateFolderTest.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/test_client/tests/src/com/owncloud/android/lib/test_project/test/CreateShareTest.java
+++ b/test_client/tests/src/com/owncloud/android/lib/test_project/test/CreateShareTest.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/test_client/tests/src/com/owncloud/android/lib/test_project/test/DeleteFileTest.java
+++ b/test_client/tests/src/com/owncloud/android/lib/test_project/test/DeleteFileTest.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/test_client/tests/src/com/owncloud/android/lib/test_project/test/DownloadFileTest.java
+++ b/test_client/tests/src/com/owncloud/android/lib/test_project/test/DownloadFileTest.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/test_client/tests/src/com/owncloud/android/lib/test_project/test/GetCapabilitiesTest.java
+++ b/test_client/tests/src/com/owncloud/android/lib/test_project/test/GetCapabilitiesTest.java
@@ -1,6 +1,6 @@
 /* ownCloud Android Library is available under MIT license
  *   @author masensio
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/test_client/tests/src/com/owncloud/android/lib/test_project/test/GetShareesTest.java
+++ b/test_client/tests/src/com/owncloud/android/lib/test_project/test/GetShareesTest.java
@@ -1,6 +1,6 @@
 /* ownCloud Android Library is available under MIT license
  *   @author David A. Velasco
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/test_client/tests/src/com/owncloud/android/lib/test_project/test/GetSharesTest.java
+++ b/test_client/tests/src/com/owncloud/android/lib/test_project/test/GetSharesTest.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/test_client/tests/src/com/owncloud/android/lib/test_project/test/MoveFileTest.java
+++ b/test_client/tests/src/com/owncloud/android/lib/test_project/test/MoveFileTest.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/test_client/tests/src/com/owncloud/android/lib/test_project/test/OwnCloudClientManagerFactoryTest.java
+++ b/test_client/tests/src/com/owncloud/android/lib/test_project/test/OwnCloudClientManagerFactoryTest.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/test_client/tests/src/com/owncloud/android/lib/test_project/test/OwnCloudClientTest.java
+++ b/test_client/tests/src/com/owncloud/android/lib/test_project/test/OwnCloudClientTest.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/test_client/tests/src/com/owncloud/android/lib/test_project/test/ReadFileTest.java
+++ b/test_client/tests/src/com/owncloud/android/lib/test_project/test/ReadFileTest.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/test_client/tests/src/com/owncloud/android/lib/test_project/test/ReadFolderTest.java
+++ b/test_client/tests/src/com/owncloud/android/lib/test_project/test/ReadFolderTest.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/test_client/tests/src/com/owncloud/android/lib/test_project/test/RemoteTest.java
+++ b/test_client/tests/src/com/owncloud/android/lib/test_project/test/RemoteTest.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/test_client/tests/src/com/owncloud/android/lib/test_project/test/RemoveShareTest.java
+++ b/test_client/tests/src/com/owncloud/android/lib/test_project/test/RemoveShareTest.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/test_client/tests/src/com/owncloud/android/lib/test_project/test/RenameFileTest.java
+++ b/test_client/tests/src/com/owncloud/android/lib/test_project/test/RenameFileTest.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/test_client/tests/src/com/owncloud/android/lib/test_project/test/SimpleFactoryManagerTest.java
+++ b/test_client/tests/src/com/owncloud/android/lib/test_project/test/SimpleFactoryManagerTest.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/test_client/tests/src/com/owncloud/android/lib/test_project/test/SingleSessionManagerTest.java
+++ b/test_client/tests/src/com/owncloud/android/lib/test_project/test/SingleSessionManagerTest.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/test_client/tests/src/com/owncloud/android/lib/test_project/test/UpdatePrivateShareTest.java
+++ b/test_client/tests/src/com/owncloud/android/lib/test_project/test/UpdatePrivateShareTest.java
@@ -1,7 +1,7 @@
 /* ownCloud Android Library is available under MIT license
  *   @author masensio
  *   @author David A. Velasco
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/test_client/tests/src/com/owncloud/android/lib/test_project/test/UpdatePublicShareTest.java
+++ b/test_client/tests/src/com/owncloud/android/lib/test_project/test/UpdatePublicShareTest.java
@@ -1,7 +1,7 @@
 /* ownCloud Android Library is available under MIT license
  *   @author masensio
  *   @author David A. Velasco
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/test_client/tests/src/com/owncloud/android/lib/test_project/test/UploadFileTest.java
+++ b/test_client/tests/src/com/owncloud/android/lib/test_project/test/UploadFileTest.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal

--- a/test_client/tests/src/com/owncloud/android/lib/test_project/test/Utils.java
+++ b/test_client/tests/src/com/owncloud/android/lib/test_project/test/Utils.java
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2015 ownCloud Inc.
+ *   Copyright (C) 2016 ownCloud GmbH.
  *   
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
cherry pick of oC lib release 0.9.13

with the 2 commits for copyright renames and share parser fix (share type is not determined by existence of <url> element in share)