### PR TITLE
fix compile after master merge

### DIFF
--- a/src/com/owncloud/android/lib/common/operations/RemoteOperationResult.java
+++ b/src/com/owncloud/android/lib/common/operations/RemoteOperationResult.java
@@ -365,7 +365,7 @@ public class RemoteOperationResult implements Serializable {
                     continue;
                 }
                 if ("www-authenticate".equals(current.getName().toLowerCase())) {
-                    mAuthenticate = current.getValue();
+                    mAuthenticateHeaders.add(current.getValue());
                     break;
                 }
             }


### PR DESCRIPTION
fixing 1.0.19
```
:compileReleaseJavaWithJavac/home/jitpack/build/src/com/owncloud/android/lib/common/operations/RemoteOperationResult.java:368: error: cannot find symbol
                    mAuthenticate = current.getValue();
                    ^
  symbol:   variable mAuthenticate
  location: class RemoteOperationResult
```

cc @mario 