### PR TITLE
Switch to ocsv2 for sharing to get the error messages directly

### DIFF
--- a/src/com/owncloud/android/lib/resources/shares/CreateRemoteShareOperation.java
+++ b/src/com/owncloud/android/lib/resources/shares/CreateRemoteShareOperation.java
@@ -170,7 +170,7 @@ public class CreateRemoteShareOperation extends RemoteOperation {
     }
 
     private boolean isSuccess(int status) {
-        return (status == HttpStatus.SC_OK);
+        return status == HttpStatus.SC_OK || status == HttpStatus.SC_FORBIDDEN;
     }
 
 }

--- a/src/com/owncloud/android/lib/resources/shares/ShareUtils.java
+++ b/src/com/owncloud/android/lib/resources/shares/ShareUtils.java
@@ -36,7 +36,7 @@ import com.owncloud.android.lib.resources.status.OwnCloudVersion;
 public class ShareUtils {
 
 	// OCS Route
-	public static final String SHARING_API_PATH ="/ocs/v1.php/apps/files_sharing/api/v1/shares"; 
+	public static final String SHARING_API_PATH ="/ocs/v2.php/apps/files_sharing/api/v1/shares";
 
     // String to build the link with the token of a share:
     public static final String SHARING_LINK_PATH_BEFORE_VERSION_8 = "/public.php?service=files&t=";

--- a/src/com/owncloud/android/lib/resources/shares/ShareXMLParser.java
+++ b/src/com/owncloud/android/lib/resources/shares/ShareXMLParser.java
@@ -24,19 +24,20 @@
 
 package com.owncloud.android.lib.resources.shares;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
+import android.util.Xml;
+
+import com.owncloud.android.lib.common.network.WebdavUtils;
+import com.owncloud.android.lib.resources.files.FileUtils;
 
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 import org.xmlpull.v1.XmlPullParserFactory;
 
-//import android.util.Log;
-import android.util.Xml;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
 
-import com.owncloud.android.lib.common.network.WebdavUtils;
-import com.owncloud.android.lib.resources.files.FileUtils;
+//import android.util.Log;
 
 /**
  * Parser for Share API Response
@@ -82,6 +83,7 @@ public class ShareXMLParser {
 	private static final String TYPE_FOLDER = "folder";
 	
 	private static final int SUCCESS = 100;
+	private static final int OK = 200;
 	private static final int ERROR_WRONG_PARAMETER = 400;
 	private static final int ERROR_FORBIDDEN = 403;
 	private static final int ERROR_NOT_FOUND = 404;
@@ -121,7 +123,7 @@ public class ShareXMLParser {
 	}
 
 	public boolean isSuccess() {
-		return mStatusCode == SUCCESS;
+		return mStatusCode == SUCCESS || mStatusCode == OK;
 	}
 
 	public boolean isForbidden() {

--- a/src/com/owncloud/android/lib/resources/shares/UpdateRemoteShareOperation.java
+++ b/src/com/owncloud/android/lib/resources/shares/UpdateRemoteShareOperation.java
@@ -203,7 +203,7 @@ public class UpdateRemoteShareOperation extends RemoteOperation {
 
                 status = client.executeMethod(put);
 
-                if (status == HttpStatus.SC_OK) {
+                if (status == HttpStatus.SC_OK || status == HttpStatus.SC_BAD_REQUEST) {
                     String response = put.getResponseBodyAsString();
 
                     // Parse xml response


### PR DESCRIPTION
https://docs.nextcloud.com/server/12/developer_manual/core/ocs-share-api.html

With v2 we get directly the error message and not first a ok/failure and then had to pick the error message.
