### PR TITLE
Add missing transfer of favorite status

### DIFF
--- a/src/com/owncloud/android/lib/resources/files/ReadRemoteFolderOperation.java
+++ b/src/com/owncloud/android/lib/resources/files/ReadRemoteFolderOperation.java
@@ -172,6 +172,7 @@ public class ReadRemoteFolderOperation extends RemoteOperation {
         file.setSize(we.size());
         file.setQuotaUsedBytes(we.quotaUsedBytes());
         file.setQuotaAvailableBytes(we.quotaAvailableBytes());
+        file.setFavorite(we.isFavorite());
         return file;
     }
 }


### PR DESCRIPTION
While reading WebDav properties we get the status of isFavorite, but do not fransfer it to RemoteFile.