### PR TITLE
Prevent npe if missing contenttype via webdav

### DIFF
--- a/src/com/owncloud/android/lib/common/network/WebdavEntry.java
+++ b/src/com/owncloud/android/lib/common/network/WebdavEntry.java
@@ -92,11 +92,15 @@ public class WebdavEntry {
             mContentType = "application/octet-stream";
             prop = propSet.get(DavPropertyName.GETCONTENTTYPE);
             if (prop != null) {
-                mContentType = (String) prop.getValue();
+                String contentType = (String) prop.getValue();
                 // dvelasco: some builds of ownCloud server 4.0.x added a trailing ';'
                 // to the MIME type ; if looks fixed, but let's be cautious
-                if (mContentType.indexOf(";") >= 0) {
-                    mContentType = mContentType.substring(0, mContentType.indexOf(";"));
+                if (contentType != null) {
+                    if (contentType.contains(";")) {
+                        mContentType = contentType.substring(0, contentType.indexOf(";"));
+                    } else {
+                        mContentType = contentType;
+                    }
                 }
             }
             


### PR DESCRIPTION
Ref: https://github.com/nextcloud/android/issues/468#issuecomment-321267591

I would like to have this in the next release as it is a bug fix which leads to showing no content at all.