### PR TITLE
Versioning app can be disabled

### DIFF
--- a/src/com/owncloud/android/lib/resources/status/GetRemoteCapabilitiesOperation.java
+++ b/src/com/owncloud/android/lib/resources/status/GetRemoteCapabilitiesOperation.java
@@ -264,8 +264,12 @@ public class GetRemoteCapabilitiesOperation extends RemoteOperation {
                                 capability.setFilesUndelete(CapabilityBooleanType.fromBooleanValue(
                                         respFiles.getBoolean(PROPERTY_UNDELETE)));
                             }
-                            capability.setFilesVersioning(CapabilityBooleanType.fromBooleanValue(
-                                    respFiles.getBoolean(PROPERTY_VERSIONING)));
+
+                            if (respFiles.has(PROPERTY_VERSIONING)) {
+                                capability.setFilesVersioning(CapabilityBooleanType.fromBooleanValue(
+                                        respFiles.getBoolean(PROPERTY_VERSIONING)));
+                            }
+
                             Log_OC.d(TAG, "*** Added " + NODE_FILES);
                         }
 


### PR DESCRIPTION
 which then leads to org.json.JSONException: No value for versioning.

If this Exception occurs the other remaining capabilites will not be set, which might lead to unexpected behaviour.

Edit: tested on a recent server and disabled all apps. Now there is no exception anylonger.