### PR TITLE
Try to fix 0 byte uploads

### DIFF
--- a/src/com/owncloud/android/lib/resources/files/UploadRemoteFileOperation.java
+++ b/src/com/owncloud/android/lib/resources/files/UploadRemoteFileOperation.java
@@ -146,7 +146,10 @@ public class UploadRemoteFileOperation extends RemoteOperation {
 			if (mRequiredEtag != null && mRequiredEtag.length() > 0) {
 				mPutMethod.addRequestHeader(IF_MATCH_HEADER, "\"" + mRequiredEtag + "\"");
 			}
-			mPutMethod.addRequestHeader(OC_TOTAL_LENGTH_HEADER, String.valueOf(f.length()));
+
+			if (f.length() > 0) {
+				mPutMethod.addRequestHeader(OC_TOTAL_LENGTH_HEADER, String.valueOf(f.length()));
+			}
             mPutMethod.addRequestHeader(OC_X_OC_MTIME_HEADER, mFileLastModifTimestamp);
 			mPutMethod.setRequestEntity(mEntity);
 			status = client.executeMethod(mPutMethod);


### PR DESCRIPTION
Signed-off-by: Mario Danic <mario@lovelyhq.com>

On certain phones, .lenght() gives us 0 bytes. We then send anticipated size as 0 bytes, and when server receives more, it deletes the file as part of integrity check.

This should prevent the issue.