### PR TITLE
Adding new ResultCode to signify power save mode upload delay

### DIFF
--- a/src/com/owncloud/android/lib/common/operations/RemoteOperationResult.java
+++ b/src/com/owncloud/android/lib/common/operations/RemoteOperationResult.java
@@ -121,7 +121,8 @@ public class RemoteOperationResult implements Serializable {
         LOCAL_FILE_NOT_FOUND,
         NOT_AVAILABLE,
         MAINTENANCE_MODE,
-        LOCK_FAILED
+        LOCK_FAILED,
+        DELAYED_IN_POWER_SAVE_MODE
     }
 
     private boolean mSuccess = false;


### PR DESCRIPTION
This change adds new enum DELAYED_IN_POWER_SAVE_MODE in ResultCode as a
preparation for https://github.com/nextcloud/android/issues/1277 that should delay upload if device is in power
save mode.