### PR TITLE
Fix transfer-encoding: chunked

### DIFF
--- a/src/com/owncloud/android/lib/resources/files/DownloadRemoteFileOperation.java
+++ b/src/com/owncloud/android/lib/resources/files/DownloadRemoteFileOperation.java
@@ -137,7 +137,16 @@ public class DownloadRemoteFileOperation extends RemoteOperation {
                         }
                     }
                 }
-                if (transferred == totalToTransfer) {  // Check if the file is completed
+                // Check if the file is completed
+                // if transfer-encoding: chunked we cannot check if the file is complete
+                Header transferEncodingHeader = mGet.getResponseHeader("Transfer-Encoding");
+                boolean transferEncoding = false;
+
+                if (transferEncodingHeader != null) {
+                    transferEncoding = transferEncodingHeader.getValue().equals("chunked");
+                }
+                
+                if (transferred == totalToTransfer || transferEncoding) {  
                     savedFile = true;
                     Header modificationTime = mGet.getResponseHeader("Last-Modified");
                     if (modificationTime == null) {
@@ -164,6 +173,8 @@ public class DownloadRemoteFileOperation extends RemoteOperation {
                 client.exhaustResponse(mGet.getResponseBodyAsStream());
             }
 
+        } catch (Exception e) {
+          Log_OC.e(TAG, e.getMessage());  
         } finally {
             if (fos != null) fos.close();
             if (!savedFile && targetFile.exists()) {


### PR DESCRIPTION
It seems to be much easier solveable than I thought. GetMethod already handles this correctly, but we had a check for the correct file length.

To check the correct file length we can use the file size in OCFile, but this then would have to be done on client/app side OR we need an additional propfind to get the size here.

I vote for keeping it simple at first here.
Later we can think about something file checksum based file checking.