### PR TITLE
Username with whitespace

### DIFF
--- a/src/com/owncloud/android/lib/resources/files/ToggleFavoriteOperation.java
+++ b/src/com/owncloud/android/lib/resources/files/ToggleFavoriteOperation.java
@@ -68,21 +68,14 @@ public class ToggleFavoriteOperation extends RemoteOperation {
         }
 
         String webDavUrl = client.getNewWebdavUri(false).toString();
-        int pos = filePath.lastIndexOf('/') + 1;
-        filePath = filePath.substring(0, pos) + Uri.encode(filePath.substring(pos));
-
-        String fullFilePath = webDavUrl + "/files/" + userID + filePath;
+        String encodedPath = Uri.encode(userID + filePath).replace("%2F", "/");
+        String fullFilePath = webDavUrl + "/files/" + encodedPath;
 
         try {
-            propPatchMethod = new PropPatchMethod(fullFilePath,
-                    newProps,
-                    removeProperties);
+            propPatchMethod = new PropPatchMethod(fullFilePath, newProps, removeProperties);
             int status = client.executeMethod(propPatchMethod);
 
-            boolean isSuccess = (
-                    status == HttpStatus.SC_MULTI_STATUS ||
-                            status == HttpStatus.SC_OK
-            );
+            boolean isSuccess = (status == HttpStatus.SC_MULTI_STATUS || status == HttpStatus.SC_OK);
 
             if (isSuccess) {
                 result = new RemoteOperationResult(true, status, propPatchMethod.getResponseHeaders());


### PR DESCRIPTION
As pointed out by @jensd0e, nextcloud can correctly handle usernames with whitespaces in it.
But toggling favorite is not working as the whitespace has to be replaced with %20 as this results in a webdav url.