### PR TITLE
Make OCSResponse a generic class, not just a class with geric method

### DIFF
--- a/src/com/owncloud/android/lib/resources/OCSRemoteOperation.java
+++ b/src/com/owncloud/android/lib/resources/OCSRemoteOperation.java
@@ -45,14 +45,13 @@ import java.lang.reflect.Type;
  */
 public abstract class OCSRemoteOperation extends RemoteOperation {
 
-    public <T> ServerResponse<T> getServerResponse(HttpMethodBase method) throws IOException {
+    public <T> T getServerResponse(HttpMethodBase method, TypeToken<T> type) throws IOException {
         String response = method.getResponseBodyAsString();
         JsonParser parser = new JsonParser();
         JsonElement element = parser.parse(response);
 
         Gson gson = new Gson();
-        Type type = new TypeToken<T>(){}.getType();
 
-        return gson.fromJson(element, type);
+        return gson.fromJson(element, type.getType());
     }
 }

--- a/src/com/owncloud/android/lib/resources/users/GetPrivateKeyOperation.java
+++ b/src/com/owncloud/android/lib/resources/users/GetPrivateKeyOperation.java
@@ -20,6 +20,7 @@
  */
 package com.owncloud.android.lib.resources.users;
 
+import com.google.gson.reflect.TypeToken;
 import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.lib.common.utils.Log_OC;
@@ -62,7 +63,7 @@ public class GetPrivateKeyOperation extends OCSRemoteOperation {
             int status = client.executeMethod(getMethod, SYNC_READ_TIMEOUT, SYNC_CONNECTION_TIMEOUT);
 
             if (status == HttpStatus.SC_OK) {
-                ServerResponse<PrivateKey> serverResponse = getServerResponse(getMethod);
+                ServerResponse<PrivateKey> serverResponse = getServerResponse(getMethod, new TypeToken<ServerResponse<PrivateKey>>(){});
 
                 result = new RemoteOperationResult(true, getMethod);
                 ArrayList<Object> keys = new ArrayList<>();

--- a/src/com/owncloud/android/lib/resources/users/GetRemoteUserInfoOperation.java
+++ b/src/com/owncloud/android/lib/resources/users/GetRemoteUserInfoOperation.java
@@ -27,6 +27,7 @@ package com.owncloud.android.lib.resources.users;
 
 import android.text.TextUtils;
 
+import com.google.gson.reflect.TypeToken;
 import com.owncloud.android.lib.common.OwnCloudBasicCredentials;
 import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.common.UserInfo;
@@ -118,7 +119,7 @@ public class GetRemoteUserInfoOperation extends OCSRemoteOperation {
                 String response = get.getResponseBodyAsString();
                 Log_OC.d(TAG, "Successful response: " + response);
 
-                ServerResponse<UserInfo> ocsResponse = getServerResponse(get);
+                ServerResponse<UserInfo> ocsResponse = getServerResponse(get, new TypeToken<ServerResponse<UserInfo>>(){});
 
                 UserInfo userInfo = ocsResponse.getOcs().getData();
 


### PR DESCRIPTION
Originally I falsly used a generic method, and assumed that it will work just like in C++. Java works a bit different when it comes to generics.

==
Sorry for introducing this bug https://github.com/nextcloud/android/issues/2101