### PR TITLE
fix nc user agent

### DIFF
--- a/src/com/owncloud/android/lib/common/OwnCloudClient.java
+++ b/src/com/owncloud/android/lib/common/OwnCloudClient.java
@@ -216,9 +216,9 @@ public class OwnCloudClient extends HttpClient {
 
             String userAgent;
             if (mUseNextcloudUserAgent) {
-                userAgent = OwnCloudClientManagerFactory.getUserAgent();
-            } else {
                 userAgent = OwnCloudClientManagerFactory.getNextcloudUserAgent();
+            } else {
+                userAgent = OwnCloudClientManagerFactory.getUserAgent();
             }
             params.setParameter(HttpMethodParams.USER_AGENT, userAgent);
 


### PR DESCRIPTION
As we now use the correct user agent for push, we get this, which is way nicer:
![device-2018-02-12-131446](https://user-images.githubusercontent.com/5836855/36096611-68a8653e-0ff7-11e8-8158-19b979198799.png)


Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>