### PR TITLE
check quota object presence before accessing it

### DIFF
--- a/src/com/owncloud/android/lib/resources/users/GetRemoteUserInfoOperation.java
+++ b/src/com/owncloud/android/lib/resources/users/GetRemoteUserInfoOperation.java
@@ -30,6 +30,7 @@ import android.text.TextUtils;
 import com.google.gson.reflect.TypeToken;
 import com.owncloud.android.lib.common.OwnCloudBasicCredentials;
 import com.owncloud.android.lib.common.OwnCloudClient;
+import com.owncloud.android.lib.common.Quota;
 import com.owncloud.android.lib.common.UserInfo;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.lib.common.utils.Log_OC;
@@ -128,7 +129,6 @@ public class GetRemoteUserInfoOperation extends OCSRemoteOperation {
                 }
 
                 if (userInfo.getQuota() == null) {
-                    Log_OC.e(TAG, "No quota in server response, use default quota");
                     userInfo.setQuota(new Quota());
                     userInfo.getQuota().setQuota(QUOTA_LIMIT_INFO_NOT_AVAILABLE);
                 }

--- a/src/com/owncloud/android/lib/resources/users/GetRemoteUserInfoOperation.java
+++ b/src/com/owncloud/android/lib/resources/users/GetRemoteUserInfoOperation.java
@@ -127,6 +127,12 @@ public class GetRemoteUserInfoOperation extends OCSRemoteOperation {
                         userInfo.setId(userID);
                 }
 
+                if (userInfo.getQuota() == null) {
+                    Log_OC.e(TAG, "No quota in server response, use default quota");
+                    userInfo.setQuota(new Quota());
+                    userInfo.getQuota().setQuota(QUOTA_LIMIT_INFO_NOT_AVAILABLE);
+                }
+                
                 if (userInfo.getQuota().getQuota() == 0) {
                     userInfo.getQuota().setQuota(QUOTA_LIMIT_INFO_NOT_AVAILABLE);
                 }


### PR DESCRIPTION
When the quota information is missing in the server response, accessing it will cause an null pointer exception.
So we check for the presence of a quota object within the server response and, if not present, we set a new quota
that reflects the fact that the quota limit is not available for this user.

NOTE: this is an untested quick fix. There are surely better solutions where to check wether the quota information is present or not but this is the place I tracked down the error, at least on my setup.

This might fix: https://github.com/nextcloud/android/issues/2192 and https://github.com/nextcloud/android/issues/2194