### PR TITLE
UserId with whitespace: fixing search

### DIFF
--- a/src/com/owncloud/android/lib/common/utils/WebDavFileUtils.java
+++ b/src/com/owncloud/android/lib/common/utils/WebDavFileUtils.java
@@ -63,6 +63,7 @@ public class WebDavFileUtils {
         String stripString = client.getWebdavUri().getPath();
         if (isSearchOperation && username != null) {
             stripString = stripString.substring(0, stripString.lastIndexOf("/")) + "/dav/files/" + username;
+            stripString = stripString.replaceAll(" ", "%20");
         }
 
         // loop to update every child


### PR DESCRIPTION
Otherwise this will fail:
https://github.com/nextcloud/android-library/blob/master/src/com/owncloud/android/lib/common/network/WebdavEntry.java#L74

as it would search for "tobi k" instead of "tobi%20k"

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>
