### PR TITLE
Remote operation result might been null

### DIFF
--- a/src/com/owncloud/android/lib/resources/files/ReadRemoteFolderOperation.java
+++ b/src/com/owncloud/android/lib/resources/files/ReadRemoteFolderOperation.java
@@ -99,26 +99,29 @@ public class ReadRemoteFolderOperation extends RemoteOperation {
                 client.exhaustResponse(query.getResponseBodyAsStream());
                 result = new RemoteOperationResult(false, query);
             }
-
         } catch (Exception e) {
             result = new RemoteOperationResult(e);
-
-
         } finally {
             if (query != null)
                 query.releaseConnection();  // let the connection available for other methods
-            if (result.isSuccess()) {
-                Log_OC.i(TAG, "Synchronized " + mRemotePath + ": " + result.getLogMessage());
+
+            if (result == null) {
+                result = new RemoteOperationResult(new Exception("unknown error"));
+                Log_OC.e(TAG, "Synchronized " + mRemotePath + ": failed");
             } else {
-                if (result.isException()) {
-                    Log_OC.e(TAG, "Synchronized " + mRemotePath + ": " + result.getLogMessage(),
-                        result.getException());
+                if (result.isSuccess()) {
+                    Log_OC.i(TAG, "Synchronized " + mRemotePath + ": " + result.getLogMessage());
                 } else {
-                    Log_OC.e(TAG, "Synchronized " + mRemotePath + ": " + result.getLogMessage());
+                    if (result.isException()) {
+                        Log_OC.e(TAG, "Synchronized " + mRemotePath + ": " + result.getLogMessage(),
+                                result.getException());
+                    } else {
+                        Log_OC.e(TAG, "Synchronized " + mRemotePath + ": " + result.getLogMessage());
+                    }
                 }
             }
-
         }
+        
         return result;
     }
 


### PR DESCRIPTION
This happened to some users according to google play console.
Frankly, I do not get this, because we
- assign a value in try block
- if try block fails, we use catch and assign a value there

So this now returns a dummy result.
If you know a better way, please say :-)

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>