### PR TITLE
Empty activites have 304 response

### DIFF
--- a/src/com/owncloud/android/lib/resources/activities/GetRemoteActivitiesOperation.java
+++ b/src/com/owncloud/android/lib/resources/activities/GetRemoteActivitiesOperation.java
@@ -134,7 +134,11 @@ public class GetRemoteActivitiesOperation extends RemoteOperation {
                 Log_OC.d(TAG, "Successful response: " + response);
                 result = new RemoteOperationResult(true, status, get.getResponseHeaders());
                 // Parse the response
-                activities = parseResult(response);
+                if (response == null) {
+                    activities = new ArrayList<>();
+                } else {
+                    activities = parseResult(response);
+                }
 
                 ArrayList<Object> data = new ArrayList<>();
                 data.add(activities);
@@ -179,6 +183,6 @@ public class GetRemoteActivitiesOperation extends RemoteOperation {
     }
 
     private boolean isSuccess(int status) {
-        return (status == HttpStatus.SC_OK);
+        return (status == HttpStatus.SC_OK || status == HttpStatus.SC_NOT_MODIFIED);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/nextcloud/android/issues/2658

![2018-05-29-140603](https://user-images.githubusercontent.com/5836855/40657793-6f74cde4-6349-11e8-8fd7-92d6631f236f.png) --> ![2018-05-30-120735](https://user-images.githubusercontent.com/5836855/40714370-be58791a-6402-11e8-82e2-f4653d93c4bd.png)

@AndyScherzinger @mario do we want to have this in 3.2? 

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>