### PR TITLE
Add passwordProtected flag to OCShares

### DIFF
--- a/src/com/owncloud/android/lib/resources/shares/OCShare.java
+++ b/src/com/owncloud/android/lib/resources/shares/OCShare.java
@@ -99,6 +99,7 @@ public class OCShare implements Parcelable, Serializable {
     private long mUserId;
     private long mRemoteId;
     private String mShareLink;
+    private boolean mIsPasswordProtected;
     
     public OCShare() {
     	super();
@@ -133,6 +134,7 @@ public class OCShare implements Parcelable, Serializable {
         mUserId = -1;
         mRemoteId = -1;
         mShareLink = "";
+        mIsPasswordProtected = false;
     }	
     
     /// Getters and Setters
@@ -257,8 +259,16 @@ public class OCShare implements Parcelable, Serializable {
         this.mShareLink = (shareLink != null) ? shareLink : "";
     }
 
+    public void setIsPasswordProtected(boolean isPasswordProtected) {
+        this.mIsPasswordProtected = isPasswordProtected;
+    }
+
     public boolean isPasswordProtected() {
-        return ShareType.PUBLIC_LINK.equals(mShareType) && mShareWith.length() > 0;
+        if (!ShareType.PUBLIC_LINK.equals(mShareType)) {
+            return mIsPasswordProtected;
+        } else {
+            return mShareWith.length() > 0;
+        }
     }
     
     /** 
@@ -306,6 +316,7 @@ public class OCShare implements Parcelable, Serializable {
         mUserId = source.readLong();
         mRemoteId = source.readLong();
         mShareLink = source.readString();
+        mIsPasswordProtected = source.readInt() == 0;
     }
 
 
@@ -332,6 +343,6 @@ public class OCShare implements Parcelable, Serializable {
         dest.writeLong(mUserId);
         dest.writeLong(mRemoteId);
         dest.writeString(mShareLink);
+        dest.writeInt(mIsPasswordProtected ? 1 : 0);
     }
-
 }

--- a/src/com/owncloud/android/lib/resources/shares/OCShare.java
+++ b/src/com/owncloud/android/lib/resources/shares/OCShare.java
@@ -316,7 +316,7 @@ public class OCShare implements Parcelable, Serializable {
         mUserId = source.readLong();
         mRemoteId = source.readLong();
         mShareLink = source.readString();
-        mIsPasswordProtected = source.readInt() == 0;
+        mIsPasswordProtected = source.readInt() == 1;
     }
 
 

--- a/src/com/owncloud/android/lib/resources/shares/ShareXMLParser.java
+++ b/src/com/owncloud/android/lib/resources/shares/ShareXMLParser.java
@@ -37,17 +37,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 
-//import android.util.Log;
-
 /**
  * Parser for Share API Response
  * @author masensio
  *
  */
-
 public class ShareXMLParser {
-
-	//private static final String TAG = ShareXMLParser.class.getSimpleName();
 
 	// No namespaces
 	private static final String ns = null;
@@ -76,6 +71,7 @@ public class ShareXMLParser {
 	private static final String NODE_TOKEN = "token";
 	private static final String NODE_STORAGE = "storage";
 	private static final String NODE_MAIL_SEND = "mail_send";
+	private static final String NODE_PASSWORD = "password";
 	private static final String NODE_SHARE_WITH_DISPLAY_NAME = "share_with_displayname";
 	
 	private static final String NODE_URL = "url";
@@ -342,6 +338,9 @@ public class ShareXMLParser {
 				if (!(value.length() == 0)) {
 					share.setExpirationDate(WebdavUtils.parseResponseDate(value).getTime()); 
 				}
+
+			} else if (name.equalsIgnoreCase(NODE_PASSWORD)) {
+				share.setIsPasswordProtected(readNode(parser, NODE_PASSWORD).length() > 0);
 
 			} else if (name.equalsIgnoreCase(NODE_TOKEN)) {
 				share.setToken(readNode(parser, NODE_TOKEN));


### PR DESCRIPTION
At the moment the server supports setting a password for a share link and for an email share. The fact that a share is actually password protected isn't reflected in the OCShare object.
For links that has been fine since if shared-with is set is is password protected  (even though this sounds strange...). This mechanism however won't work for email shares thus the client using the library should be able to parse/get/set this info and later store this fact to the database.