### PR TITLE
Fix double slash on search results with folder, e.g. "/test//folder//"

### DIFF
--- a/src/com/owncloud/android/lib/common/network/WebdavEntry.java
+++ b/src/com/owncloud/android/lib/common/network/WebdavEntry.java
@@ -84,7 +84,7 @@ public class WebdavEntry {
         if (ms.getStatus().length != 0) {
             mUri = ms.getHref();
 
-            mPath = mUri.split(splitElement, 2)[1];
+            mPath = mUri.split(splitElement, 2)[1].replace("//", "/");
 
             int status = ms.getStatus()[0].getStatusCode();
             if ( status == CODE_PROP_NOT_FOUND ) {

--- a/src/com/owncloud/android/lib/common/utils/WebDavFileUtils.java
+++ b/src/com/owncloud/android/lib/common/utils/WebDavFileUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Nextcloud Android client application
  *
  * @author Mario Danic
@@ -67,7 +67,7 @@ public class WebDavFileUtils {
         }
 
         // loop to update every child
-        RemoteFile remoteFile = null;
+        RemoteFile remoteFile;
         MultiStatusResponse[] responses = remoteData.getResponses();
         for (int i = start; i < responses.length; i++) {
             /// new OCFile instance with the data from the server


### PR DESCRIPTION
Ref: https://github.com/nextcloud/server/issues/9892

Depending on the answer by server team, we still should add this as not all server get upgraded quick enough.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>