### PR TITLE
Skip pullapprove on dependencies labels

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -21,6 +21,10 @@ group_defaults:
     enabled: false
   reset_on_reopened:
     enabled: true
+  conditions:
+    labels:
+      exclude:
+        - dependencies
 
 groups:
   code-review:


### PR DESCRIPTION
Same as in android repo: if drone is fine, we merge the dependency so that it can be tested with next dev version.