### PR TITLE
codacy: A getX() method which returns a boolean should be named isX()

### DIFF
--- a/src/com/owncloud/android/lib/resources/files/FileVersion.java
+++ b/src/com/owncloud/android/lib/resources/files/FileVersion.java
@@ -29,6 +29,8 @@ import android.os.Parcelable;
 
 import com.owncloud.android.lib.common.network.WebdavEntry;
 
+import java.io.Serializable;
+
 /**
  * Contains the data of a versioned file from a WebDavEntry.
  *
@@ -39,7 +41,7 @@ public class FileVersion implements Parcelable, ServerFileInterface {
     /**
      * Generated - should be refreshed every time the class changes!!
      */
-    private static final long serialVersionUID = 3130865437811248455L;
+    private static final long serialVersionUID = 5276021208979796734L;
 
     public static final String DIRECTORY = "DIR";
 
@@ -49,7 +51,7 @@ public class FileVersion implements Parcelable, ServerFileInterface {
     private String remoteId;
 
     @Override
-    public boolean getIsFavorite() {
+    public boolean isFavorite() {
         return false;
     }
 

--- a/src/com/owncloud/android/lib/resources/files/ServerFileInterface.java
+++ b/src/com/owncloud/android/lib/resources/files/ServerFileInterface.java
@@ -12,7 +12,7 @@ public interface ServerFileInterface {
     
     String getRemoteId();
     
-    boolean getIsFavorite();
+    boolean isFavorite();
     
     boolean isFolder();
     

--- a/src/com/owncloud/android/lib/resources/files/TrashbinFile.java
+++ b/src/com/owncloud/android/lib/resources/files/TrashbinFile.java
@@ -41,7 +41,7 @@ public class TrashbinFile implements Parcelable, Serializable, ServerFileInterfa
     /**
      * Generated - should be refreshed every time the class changes!!
      */
-    private static final long serialVersionUID = 3130865437811248452L;
+    private static final long serialVersionUID = -432910968238077774L;
 
     public static final String DIRECTORY = "DIR";
 
@@ -63,7 +63,7 @@ public class TrashbinFile implements Parcelable, Serializable, ServerFileInterfa
     }
 
     @Override
-    public boolean getIsFavorite() {
+    public boolean isFavorite() {
         return false;
     }
 


### PR DESCRIPTION
boolean returning access-method should start with *is* not with *get*

needed by https://github.com/nextcloud/android/pull/3070