### PR TITLE
Revert api instead of compile

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ repositories {
 }
 
 dependencies {
-    api 'org.apache.jackrabbit:jackrabbit-webdav:2.12.6'
+    compile 'org.apache.jackrabbit:jackrabbit-webdav:2.12.6'
     implementation 'org.parceler:parceler-api:1.1.11'
     annotationProcessor 'org.parceler:parceler:1.1.9'
     implementation group: 'com.google.code.gson', name: 'gson', version: '2.8.5'


### PR DESCRIPTION
As far as I understood from https://developer.android.com/studio/build/dependencies?utm_source=android-studio#dependency_configurations "compile" should have been replaced by "api", but this leads to failing client:

```
 error: package org.apache.commons.httpclient does not exist
error: cannot find symbol class GetMethod
```

So reverting this for now.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>