### PR TITLE
Bump parceler 1.1.11 to 1.1.12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,8 +20,8 @@ repositories {
 
 dependencies {
     compile 'org.apache.jackrabbit:jackrabbit-webdav:2.12.6'
-    implementation 'org.parceler:parceler-api:1.1.11'
-    annotationProcessor 'org.parceler:parceler:1.1.11'
+    implementation 'org.parceler:parceler-api:1.1.12'
+    annotationProcessor 'org.parceler:parceler:1.1.12'
     implementation group: 'com.google.code.gson', name: 'gson', version: '2.8.5'
     implementation "com.android.support:support-annotations:28.0.0"
     


### PR DESCRIPTION
For some reasons dependabot did not detect this lib update on the library project but only on the app project. Thus manually pushing the versions and opening a PR.

cc @tobiasKaminsky 