### PR TITLE
Bugfix: CreateFolderRemoteOperation sends wrong user-agent

### DIFF
--- a/src/com/owncloud/android/lib/resources/files/CreateFolderRemoteOperation.java
+++ b/src/com/owncloud/android/lib/resources/files/CreateFolderRemoteOperation.java
@@ -90,7 +90,6 @@ public class CreateFolderRemoteOperation extends RemoteOperation {
         MkColMethod mkCol = null;
         try {
             mkCol = new MkColMethod(client.getWebdavUri() + WebdavUtils.encodePath(mRemotePath));
-            client.setUseNextcloudUserAgent(true);
             client.executeMethod(mkCol, READ_TIMEOUT, CONNECTION_TIMEOUT);
 
             if (HttpStatus.SC_METHOD_NOT_ALLOWED == mkCol.getStatusCode()) {


### PR DESCRIPTION
Bugfix: `CreateFolderRemoteOperation` sent the MKCOL request with the wrong user agent. Instead of the custom agent defined by `OwnCloudClientManagerFactory`, it always used the default nextcloud user-agent, as can be seen in the Apache log:

    admin [14/Jan/2019:15:37:55 +0100] "MKCOL /nextcloud/remote.php/webdav/ImageMeter/wurzel%205/test.imi HTTP/1.1" 201 1212 "-" "Jakarta Commons-HttpClient/3.1"
    admin [14/Jan/2019:15:37:55 +0100] "PROPFIND /nextcloud/remote.php/webdav/ImageMeter/wurzel%205/test.imi/thumb-640x512-Bild_vom_14._Jan._2019.jpg HTTP/1.1" 404 1525 "-" "ImageMeter/2.20.2"
    admin [14/Jan/2019:15:37:55 +0100] "PUT /nextcloud/remote.php/webdav/ImageMeter/wurzel%205/test.imi/thumb-640x512-Bild_vom_14._Jan._2019.jpg HTTP/1.1" 500 6002 "-" "ImageMeter/2.20.2"
