### PR TITLE
Fix an issue with not populating all the fields

### DIFF
--- a/src/com/owncloud/android/lib/resources/files/ReadFolderRemoteOperation.java
+++ b/src/com/owncloud/android/lib/resources/files/ReadFolderRemoteOperation.java
@@ -159,7 +159,7 @@ public class ReadFolderRemoteOperation extends RemoteOperation {
      * Creates and populates a new {@link RemoteFile} object with the data read from the server.
      *
      * @param we WebDAV entry read from the server for a WebDAV resource (remote file or folder).
-     * @return New OCFile instance representing the remote resource described by we.
+     * @return New RemoteFile instance representing the remote resource described by we.
      */
     private RemoteFile fillOCFile(WebdavEntry we) {
         RemoteFile file = new RemoteFile(we.decodedPath());

--- a/src/com/owncloud/android/lib/resources/files/model/RemoteFile.java
+++ b/src/com/owncloud/android/lib/resources/files/model/RemoteFile.java
@@ -232,10 +232,13 @@ public class RemoteFile implements Parcelable, Serializable {
         setRemoteId(we.remoteId());
         setSize(we.size());
         setFavorite(we.isFavorite());
+        setIsEncrypted(we.isEncrypted());
         setMountType(we.getMountType());
         setOwnerId(we.getOwnerId());
         setOwnerDisplayName(we.getOwnerDisplayName());
         setNote(we.getNote());
+        setUnreadCommentsCount(we.getUnreadCommentsCount());
+        setHasPreview(we.hasPreview());
     }
 
     /**


### PR DESCRIPTION
So I've been banging my head against the wall for hours wondering why don't I get all properties, and here it is!

I would have assumed this caused more bugs in the app, but no idea as we have so many places that we fill the RemoteFile in both the app and the library.

That should go into one place so things like this won't happen, but here is a fix for the current problem.

Please try to get me a library release out of this - thanks!

Signed-off-by: Mario Danic <mario@lovelyhq.com>