### PR TITLE
prevent double slash, as remotePath always has a leading "/"

### DIFF
--- a/src/main/java/com/owncloud/android/lib/resources/trashbin/ReadTrashbinFolderRemoteOperation.java
+++ b/src/main/java/com/owncloud/android/lib/resources/trashbin/ReadTrashbinFolderRemoteOperation.java
@@ -74,7 +74,7 @@ public class ReadTrashbinFolderRemoteOperation extends RemoteOperation {
         PropFindMethod query = null;
 
         try {
-            String baseUri = client.getNewWebdavUri() + "/trashbin/" + client.getUserId() + "/trash/";
+            String baseUri = client.getNewWebdavUri() + "/trashbin/" + client.getUserId() + "/trash";
             DavPropertyNameSet propSet = WebdavUtils.getTrashbinPropSet();
                 
             query = new PropFindMethod(baseUri + WebdavUtils.encodePath(remotePath), propSet, DavConstants.DEPTH_1);


### PR DESCRIPTION
Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>