### PR TITLE
Make response member in OkHttpMethodBase nullable

### DIFF
--- a/src/main/java/com/nextcloud/common/NextcloudClient.kt
+++ b/src/main/java/com/nextcloud/common/NextcloudClient.kt
@@ -107,9 +107,9 @@ class NextcloudClient(var baseUri: Uri, val context: Context) : OkHttpClient() {
                     destination = redirectedDestination
 
                     if (getRequestHeader("Destination").isNullOrEmpty()) {
-                        method.requestHeaders.put("destination", destination)
+                        method.addRequestHeader("destination", destination)
                     } else {
-                        method.requestHeaders.put("Destination", destination)
+                        method.addRequestHeader("Destination", destination)
                     }
                 }
                 status = method.execute(this)

--- a/src/main/java/com/owncloud/android/lib/resources/activities/GetActivitiesRemoteOperation.java
+++ b/src/main/java/com/owncloud/android/lib/resources/activities/GetActivitiesRemoteOperation.java
@@ -130,8 +130,7 @@ public class GetActivitiesRemoteOperation extends RemoteOperation {
 
             status = client.execute(get);
             String response = get.getResponseBodyAsString();
-
-            String nextPageHeader = get.response.header("X-Activity-Last-Given");
+            String nextPageHeader = get.getResponseHeader("X-Activity-Last-Given");
             if (nextPageHeader != null) {
                 lastGiven = Integer.parseInt(nextPageHeader);
             } else {


### PR DESCRIPTION
The class uses non-null lateinit variable that
is not initialized. The member should be of
nullable type.

Fixes nextcloud/android#5073
Fixes nextcloud/android#5102
Fixes nextcloud/android#5100
Fixes nextcloud/android#5142
Fixes nextcloud/android#5156

Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>