### PR TITLE
Name for text creation is now only "text document", removed "new"

### DIFF
--- a/src/androidTest/java/com/nextcloud/android/lib/resources/directediting/DirectEditingObtainRemoteOperationTest.java
+++ b/src/androidTest/java/com/nextcloud/android/lib/resources/directediting/DirectEditingObtainRemoteOperationTest.java
@@ -45,7 +45,7 @@ public class DirectEditingObtainRemoteOperationTest extends AbstractIT {
         assertEquals("Nextcloud Text", directEditing.editors.get("text").name);
         assertEquals("text/plain", directEditing.editors.get("text").optionalMimetypes.get(0));
 
-        assertEquals("New text document", directEditing.creators.get("textdocument").name);
+        assertEquals("text document", directEditing.creators.get("textdocument").name);
         assertFalse(directEditing.creators.get("textdocument").templates);
     }
 }


### PR DESCRIPTION
Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>