### PR TITLE
Fix creation of files with multibyte filename

### DIFF
--- a/src/main/java/com/nextcloud/android/lib/resources/directediting/DirectEditingCreateFileRemoteOperation.java
+++ b/src/main/java/com/nextcloud/android/lib/resources/directediting/DirectEditingCreateFileRemoteOperation.java
@@ -66,6 +66,7 @@ public class DirectEditingCreateFileRemoteOperation extends RemoteOperation {
 
         try {
             postMethod = new PostMethod(client.getBaseUri() + DIRECT_ENDPOINT + JSON_FORMAT);
+            postMethod.getParams().setContentCharset("utf-8");
             postMethod.addParameter("path", path);
             postMethod.addParameter("editorId", editor);
             postMethod.addParameter("creatorId", creator);


### PR DESCRIPTION
Hi,

I could not create a text file like "あ.md", possibly because of multibyte characters, and request actually sent seems to be "?.md" in such a situation. My environment is https://github.com/nextcloud/android master with Android Emulator. It also happened on NextCloud for Android 3.10.1 on Google Play on BlackBerry KeyONE with Android 8.1.0.

This seems to be almost the same as https://github.com/nextcloud/android-library/pull/384 , but because of a neighbor class. I tried to fix it, but I could not find a way to check whether it fixes this bug or not, so sorry, I did not any test for this pull request.

Could take a look at this, and give me a comment? If many should be done before merging, then I will create an issue for this according to comments.