### PR TITLE
Increase maximum number of allowed connections in HTTP connection pool

### DIFF
--- a/src/main/java/com/owncloud/android/lib/common/network/NetworkUtils.java
+++ b/src/main/java/com/owncloud/android/lib/common/network/NetworkUtils.java
@@ -188,8 +188,8 @@ public class NetworkUtils {
     static public MultiThreadedHttpConnectionManager getMultiThreadedConnManager() {
         if (mConnManager == null) {
             mConnManager = new MultiThreadedHttpConnectionManager();
-            mConnManager.getParams().setDefaultMaxConnectionsPerHost(5);
-            mConnManager.getParams().setMaxTotalConnections(5);
+            mConnManager.getParams().setDefaultMaxConnectionsPerHost(64);
+            mConnManager.getParams().setMaxTotalConnections(64);
         }
         return mConnManager;
     }


### PR DESCRIPTION
Not all requests release connections, which leads to connection
pool starvation and lock-ups during files upload.

Apache's HTTP client handles "lost" connections by a GC
hook and removes unreachable objects from the pool.

However, this mechanism requires actual GC to occur, which
may not happen if the app is otherwise idle.

One way of observing this problem is to:
1) start upload of ~30 decently sized photos (few mbytes)
2) hang around in Uploads screen and observe progress bars
3) stop the app using debugger and observe FileUploaderThread
   being blocked in MultiThreadedHttpConnectionManager.doGetConnection()
   (calling wait())
4) when upload stalls, force GC using Android Studio profiler; this
   should unblock the connection pool and resume uploads

Increasing maximum number of allowed connections gives
more room for GC to kick in and reclaim stale connections,
which in turn should greatly improve stability of multi-file
uploads.

Other method would be to walk around the app, causing memory
allocations and triggering a GC as a side effect.

Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>