### PR TITLE
Harden CapabilityBooleanType: can never be null

### DIFF
--- a/src/main/java/com/owncloud/android/lib/resources/status/CapabilityBooleanType.java
+++ b/src/main/java/com/owncloud/android/lib/resources/status/CapabilityBooleanType.java
@@ -24,27 +24,28 @@
  */
 package com.owncloud.android.lib.resources.status;
 
+import androidx.annotation.NonNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 /**
  * Enum for Boolean Type in OCCapability parameters, with values:
  * -1 - Unknown
- *  0 - False
- *  1 - True
+ * 0 - False
+ * 1 - True
  */
 @AllArgsConstructor
 public enum CapabilityBooleanType {
-    UNKNOWN (-1),
-    FALSE (0),
-    TRUE (1);
+    UNKNOWN(-1),
+    FALSE(0),
+    TRUE(1);
 
-    @Getter private int value;
+    @Getter
+    private int value;
 
-    public static CapabilityBooleanType fromValue(int value)
-    {
-        switch (value)
-        {
+    public static @NonNull
+    CapabilityBooleanType fromValue(int value) {
+        switch (value) {
             case -1:
                 return UNKNOWN;
             case 0:
@@ -52,26 +53,26 @@ public enum CapabilityBooleanType {
             case 1:
                 return TRUE;
         }
-        return null;
+        return UNKNOWN;
     }
 
-    public static CapabilityBooleanType fromBooleanValue(boolean boolValue){
-        if (boolValue){
+    public static CapabilityBooleanType fromBooleanValue(boolean boolValue) {
+        if (boolValue) {
             return TRUE;
         } else {
             return FALSE;
         }
     }
 
-    public boolean isUnknown(){
+    public boolean isUnknown() {
         return getValue() == -1;
     }
 
-    public boolean isFalse(){
+    public boolean isFalse() {
         return getValue() == 0;
     }
 
-    public boolean isTrue(){
+    public boolean isTrue() {
         return getValue() == 1;
     }
 }

--- a/src/test/java/com/owncloud/android/lib/resources/status/CapabilityBooleanTypeTest.java
+++ b/src/test/java/com/owncloud/android/lib/resources/status/CapabilityBooleanTypeTest.java
@@ -1,0 +1,52 @@
+/*
+ * Nextcloud Android client application
+ *
+ * @author Tobias Kaminsky
+ * Copyright (C) 2020 Tobias Kaminsky
+ * Copyright (C) 2020 Nextcloud GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.owncloud.android.lib.resources.status;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class CapabilityBooleanTypeTest {
+
+    @Test
+    public void test() {
+        assertTrue(CapabilityBooleanType.fromBooleanValue(true).isTrue());
+        assertTrue(CapabilityBooleanType.fromBooleanValue(false).isFalse());
+
+        assertTrue(CapabilityBooleanType.fromValue(-2).isUnknown());
+        assertTrue(CapabilityBooleanType.fromValue(-1).isUnknown());
+        assertTrue(CapabilityBooleanType.fromValue(-0).isFalse());
+        assertTrue(CapabilityBooleanType.fromValue(1).isTrue());
+        assertTrue(CapabilityBooleanType.fromValue(2).isUnknown());
+
+        assertTrue(CapabilityBooleanType.valueOf("UNKNOWN").isUnknown());
+        assertTrue(CapabilityBooleanType.valueOf("FALSE").isFalse());
+        assertTrue(CapabilityBooleanType.valueOf("TRUE").isTrue());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testException() {
+        CapabilityBooleanType.valueOf("wrongValue");
+    }
+
+}


### PR DESCRIPTION
Fix https://github.com/nextcloud/android/issues/5045

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>