### PR TITLE
remove fileDrop capability

### DIFF
--- a/src/main/java/com/owncloud/android/lib/resources/status/GetCapabilitiesRemoteOperation.java
+++ b/src/main/java/com/owncloud/android/lib/resources/status/GetCapabilitiesRemoteOperation.java
@@ -73,7 +73,6 @@ public class GetCapabilitiesRemoteOperation extends RemoteOperation {
     private static final String NODE_PUBLIC = "public";
     private static final String NODE_PASSWORD = "password";
     private static final String NODE_ASK_FOR_OPTIONAL_PASSWORD = "askForOptionalPassword";
-    private static final String NODE_FILES_DROP = "upload_files_drop";
     private static final String NODE_EXPIRE_DATE = "expire_date";
     private static final String NODE_USER = "user";
     private static final String NODE_FEDERATION = "federation";
@@ -264,12 +263,6 @@ public class GetCapabilitiesRemoteOperation extends RemoteOperation {
                                         capability.setFilesSharingPublicAskForOptionalPassword(
                                                 CapabilityBooleanType.FALSE);
                                     }
-                                }
-                                if(respPublic.has(NODE_FILES_DROP)) {
-                                    capability.setFilesFileDrop(
-                                            CapabilityBooleanType.fromBooleanValue(
-                                                    respPublic.getBoolean(NODE_FILES_DROP))
-                                    );
                                 }
                                 if(respPublic.has(NODE_EXPIRE_DATE)){
                                     JSONObject respExpireDate = respPublic.getJSONObject(NODE_EXPIRE_DATE);

--- a/src/main/java/com/owncloud/android/lib/resources/status/OCCapability.java
+++ b/src/main/java/com/owncloud/android/lib/resources/status/OCCapability.java
@@ -81,7 +81,6 @@ public class OCCapability {
     private CapabilityBooleanType filesBigFileChunking;
     private CapabilityBooleanType filesUndelete;
     private CapabilityBooleanType filesVersioning;
-    private CapabilityBooleanType filesFileDrop;
 
     private CapabilityBooleanType supportsNotificationsV1;
     private CapabilityBooleanType supportsNotificationsV2;
@@ -149,7 +148,6 @@ public class OCCapability {
         filesBigFileChunking = CapabilityBooleanType.UNKNOWN;
         filesUndelete = CapabilityBooleanType.UNKNOWN;
         filesVersioning = CapabilityBooleanType.UNKNOWN;
-        filesFileDrop = CapabilityBooleanType.UNKNOWN;
 
         supportsNotificationsV1 = CapabilityBooleanType.UNKNOWN;
         supportsNotificationsV2 = CapabilityBooleanType.UNKNOWN;


### PR DESCRIPTION
This is in NC since 12, so we can rely on having this always enabled. 

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>