### PR TITLE
Make it possible to leave upload retries enabled

### DIFF
--- a/src/androidTest/java/com/nextcloud/android/lib/resources/directediting/DirectEditingOpenFileRemoteOperationTest.java
+++ b/src/androidTest/java/com/nextcloud/android/lib/resources/directediting/DirectEditingOpenFileRemoteOperationTest.java
@@ -47,7 +47,7 @@ public class DirectEditingOpenFileRemoteOperationTest extends AbstractIT {
         // create file
         String filePath = createFile("text");
         String remotePath = "/text.md";
-        TestCase.assertTrue(new UploadFileRemoteOperation(filePath, remotePath, "text/markdown", "123")
+        TestCase.assertTrue(new UploadFileRemoteOperation(filePath, remotePath, "text/markdown", "123", true)
                                     .execute(client).isSuccess());
 
         TestCase.assertTrue(new ReadFileRemoteOperation(remotePath).execute(client).isSuccess());
@@ -66,7 +66,7 @@ public class DirectEditingOpenFileRemoteOperationTest extends AbstractIT {
         // create file
         String filePath = createFile("text");
         String remotePath = "/äää.md";
-        TestCase.assertTrue(new UploadFileRemoteOperation(filePath, remotePath, "text/markdown", "123")
+        TestCase.assertTrue(new UploadFileRemoteOperation(filePath, remotePath, "text/markdown", "123", true)
                 .execute(client).isSuccess());
 
         TestCase.assertTrue(new ReadFileRemoteOperation(remotePath).execute(client).isSuccess());
@@ -85,7 +85,7 @@ public class DirectEditingOpenFileRemoteOperationTest extends AbstractIT {
         // create file
         String filePath = createFile("text");
         String remotePath = "/あ.md";
-        TestCase.assertTrue(new UploadFileRemoteOperation(filePath, remotePath, "text/markdown", "123")
+        TestCase.assertTrue(new UploadFileRemoteOperation(filePath, remotePath, "text/markdown", "123", true)
                 .execute(client).isSuccess());
 
         TestCase.assertTrue(new ReadFileRemoteOperation(remotePath).execute(client).isSuccess());

--- a/src/androidTest/java/com/nextcloud/android/lib/richWorkspace/RichWorkspaceDirectEditingRemoteOperationTest.java
+++ b/src/androidTest/java/com/nextcloud/android/lib/richWorkspace/RichWorkspaceDirectEditingRemoteOperationTest.java
@@ -75,7 +75,8 @@ public class RichWorkspaceDirectEditingRemoteOperationTest extends AbstractIT {
         RemoteOperationResult uploadResult = new UploadFileRemoteOperation(txtFile.getAbsolutePath(),
                 filePath,
                 "txt/plain",
-                String.valueOf(System.currentTimeMillis() / 1000))
+                String.valueOf(System.currentTimeMillis() / 1000),
+                true)
                 .execute(client);
 
         assertTrue("Error uploading file " + filePath + ": " + uploadResult, uploadResult.isSuccess());

--- a/src/androidTest/java/com/owncloud/android/CopyFileIT.java
+++ b/src/androidTest/java/com/owncloud/android/CopyFileIT.java
@@ -188,7 +188,7 @@ public class CopyFileIT extends AbstractIT {
         File txtFile = getFile(ASSETS__TEXT_FILE_NAME);
 
         for (String filePath : FILES_IN_FIXTURE) {
-            result = new UploadFileRemoteOperation(txtFile.getAbsolutePath(), filePath, "txt/plain", String.valueOf(System.currentTimeMillis() / 1000)).execute(client);
+            result = new UploadFileRemoteOperation(txtFile.getAbsolutePath(), filePath, "txt/plain", String.valueOf(System.currentTimeMillis() / 1000), true).execute(client);
 
             assertTrue("Error uploading file " + filePath + ": " + result, result.isSuccess());
         }

--- a/src/androidTest/java/com/owncloud/android/DeleteFileTest.java
+++ b/src/androidTest/java/com/owncloud/android/DeleteFileTest.java
@@ -63,7 +63,8 @@ public class DeleteFileTest extends AbstractIT {
 
         File textFile = getFile(ASSETS__TEXT_FILE_NAME);
         result = new UploadFileRemoteOperation(textFile.getAbsolutePath(), mFullPath2File, "txt/plain",
-                                               String.valueOf(System.currentTimeMillis() / 1000)).execute(client);
+                                               String.valueOf(System.currentTimeMillis() / 1000),
+                                               true).execute(client);
 
         assertTrue("Error uploading file " + textFile.getAbsolutePath() + ": " + result, result.isSuccess());
     }

--- a/src/androidTest/java/com/owncloud/android/lib/common/operations/CreateShareTest.java
+++ b/src/androidTest/java/com/owncloud/android/lib/common/operations/CreateShareTest.java
@@ -60,7 +60,8 @@ public class CreateShareTest extends AbstractIT {
         RemoteOperationResult result = new UploadFileRemoteOperation(textFile.getAbsolutePath(),
                                                                      mFullPath2FileToShare,
                                                                      "txt/plain",
-                                                                     String.valueOf(System.currentTimeMillis() / 1000))
+                                                                     String.valueOf(System.currentTimeMillis() / 1000),
+                                                                     true)
                 .execute(client);
 
         assertTrue("Error uploading file " + textFile + ": " + result, result.isSuccess());

--- a/src/androidTest/java/com/owncloud/android/lib/common/operations/RemoveShareTest.java
+++ b/src/androidTest/java/com/owncloud/android/lib/common/operations/RemoveShareTest.java
@@ -54,7 +54,8 @@ public class RemoveShareTest extends AbstractIT {
         assertTrue(new UploadFileRemoteOperation(textFile.getAbsolutePath(),
                                                  FILE_TO_UNSHARE,
                                                  "txt/plain",
-                                                 String.valueOf(System.currentTimeMillis() / 1000))
+                                                 String.valueOf(System.currentTimeMillis() / 1000),
+                                                 true)
                            .execute(client).isSuccess());
 
         RemoteOperationResult result = new CreateShareRemoteOperation(FILE_TO_UNSHARE,

--- a/src/androidTest/java/com/owncloud/android/lib/resources/files/SearchRemoteOperationTest.java
+++ b/src/androidTest/java/com/owncloud/android/lib/resources/files/SearchRemoteOperationTest.java
@@ -72,7 +72,7 @@ public class SearchRemoteOperationTest extends AbstractIT {
         for (int i = 0; i < 10; i++) {
             String filePath = createFile("image" + i);
             String remotePath = "/image" + i + ".jpg";
-            assertTrue(new UploadFileRemoteOperation(filePath, remotePath, "image/jpg", "123")
+            assertTrue(new UploadFileRemoteOperation(filePath, remotePath, "image/jpg", "123", true)
                                .execute(client).isSuccess());
         }
 
@@ -90,7 +90,7 @@ public class SearchRemoteOperationTest extends AbstractIT {
         for (int i = 0; i < 10; i++) {
             String filePath = createFile("image" + i);
             String remotePath = "/image" + i + ".jpg";
-            assertTrue(new UploadFileRemoteOperation(filePath, remotePath, "image/jpg", "123")
+            assertTrue(new UploadFileRemoteOperation(filePath, remotePath, "image/jpg", "123", true)
                                .execute(client).isSuccess());
         }
 
@@ -106,7 +106,7 @@ public class SearchRemoteOperationTest extends AbstractIT {
         for (int i = 0; i < 10; i++) {
             String filePath = createFile("image" + i);
             String remotePath = "/image" + i + ".jpg";
-            assertTrue(new UploadFileRemoteOperation(filePath, remotePath, "image/jpg", "123")
+            assertTrue(new UploadFileRemoteOperation(filePath, remotePath, "image/jpg", "123", true)
                                .execute(client).isSuccess());
         }
 
@@ -157,19 +157,19 @@ public class SearchRemoteOperationTest extends AbstractIT {
     public void testRecentlyModifiedSearch() throws IOException {
         long now = System.currentTimeMillis() / 1000;
         String filePath = createFile("image");
-        assertTrue(new UploadFileRemoteOperation(filePath, "/image.jpg", "image/jpg", String.valueOf(now - 50))
+        assertTrue(new UploadFileRemoteOperation(filePath, "/image.jpg", "image/jpg", String.valueOf(now - 50), true)
                            .execute(client).isSuccess());
 
         String videoPath = createFile("video");
-        assertTrue(new UploadFileRemoteOperation(videoPath, "/video.mp4", "video/mpeg", String.valueOf(now - 10))
+        assertTrue(new UploadFileRemoteOperation(videoPath, "/video.mp4", "video/mpeg", String.valueOf(now - 10), true)
                            .execute(client).isSuccess());
 
         String pdfPath = createFile("pdf");
-        assertTrue(new UploadFileRemoteOperation(pdfPath, "/pdf.pdf", "application/pdf", String.valueOf(now - 30))
+        assertTrue(new UploadFileRemoteOperation(pdfPath, "/pdf.pdf", "application/pdf", String.valueOf(now - 30), true)
                            .execute(client).isSuccess());
 
         String oldPath = createFile("pdf");
-        assertTrue(new UploadFileRemoteOperation(oldPath, "/old.pdf", "application/pdf", "1")
+        assertTrue(new UploadFileRemoteOperation(oldPath, "/old.pdf", "application/pdf", "1", true)
                            .execute(client).isSuccess());
 
         SearchRemoteOperation sut = new SearchRemoteOperation("",
@@ -198,11 +198,11 @@ public class SearchRemoteOperationTest extends AbstractIT {
     @Test
     public void testPhotoSearch() throws IOException {
         String imagePath = createFile("image");
-        assertTrue(new UploadFileRemoteOperation(imagePath, "/image.jpg", "image/jpg", "123")
+        assertTrue(new UploadFileRemoteOperation(imagePath, "/image.jpg", "image/jpg", "123", true)
                            .execute(client).isSuccess());
 
         String filePath = createFile("pdf");
-        assertTrue(new UploadFileRemoteOperation(filePath, "/pdf.pdf", "application/pdf", "123")
+        assertTrue(new UploadFileRemoteOperation(filePath, "/pdf.pdf", "application/pdf", "123", true)
                            .execute(client).isSuccess());
 
         SearchRemoteOperation sut = new SearchRemoteOperation("image/%", SearchRemoteOperation.SearchType.PHOTO_SEARCH,
@@ -221,7 +221,7 @@ public class SearchRemoteOperationTest extends AbstractIT {
             assertTrue(new UploadFileRemoteOperation(filePath,
                                                      remotePath,
                                                      "image/jpg",
-                                                     String.valueOf(100000 + i * 10000))
+                                                     String.valueOf(100000 + i * 10000), true)
                                .execute(client).isSuccess());
         }
 
@@ -247,7 +247,7 @@ public class SearchRemoteOperationTest extends AbstractIT {
         for (int i = 0; i < 10; i++) {
             String filePath = createFile("image" + i);
             String remotePath = "/image" + i + ".jpg";
-            assertTrue(new UploadFileRemoteOperation(filePath, remotePath, "image/jpg", String.valueOf(i))
+            assertTrue(new UploadFileRemoteOperation(filePath, remotePath, "image/jpg", String.valueOf(i), true)
                                .execute(client).isSuccess());
         }
 
@@ -274,7 +274,7 @@ public class SearchRemoteOperationTest extends AbstractIT {
             assertTrue(new UploadFileRemoteOperation(filePath,
                                                      remotePath,
                                                      "image/jpg",
-                                                     String.valueOf(100000 + i * 10000))
+                                                     String.valueOf(100000 + i * 10000), true)
                                .execute(client).isSuccess());
         }
 
@@ -301,15 +301,15 @@ public class SearchRemoteOperationTest extends AbstractIT {
         for (int i = 0; i < 10; i++) {
             String filePath = createFile("image" + i);
             String remotePath = "/image" + i + ".jpg";
-            assertTrue(new UploadFileRemoteOperation(filePath, remotePath, "image/jpg", "123")
+            assertTrue(new UploadFileRemoteOperation(filePath, remotePath, "image/jpg", "123", true)
                                .execute(client).isSuccess());
         }
         String videoPath = createFile("video");
-        assertTrue(new UploadFileRemoteOperation(videoPath, "/video.mp4", "video/mpeg", "123")
+        assertTrue(new UploadFileRemoteOperation(videoPath, "/video.mp4", "video/mpeg", "123", true)
                            .execute(client).isSuccess());
 
         String filePath = createFile("pdf");
-        assertTrue(new UploadFileRemoteOperation(filePath, "/pdf.pdf", "application/pdf", "123")
+        assertTrue(new UploadFileRemoteOperation(filePath, "/pdf.pdf", "application/pdf", "123", true)
                            .execute(client).isSuccess());
 
         SearchRemoteOperation sut = new SearchRemoteOperation("image/%", SearchRemoteOperation.SearchType.GALLERY_SEARCH,
@@ -325,7 +325,7 @@ public class SearchRemoteOperationTest extends AbstractIT {
         for (int i = 0; i < 10; i++) {
             String filePath = createFile("image" + i);
             String remotePath = "/image" + i + ".jpg";
-            assertTrue(new UploadFileRemoteOperation(filePath, remotePath, "image/jpg", "123")
+            assertTrue(new UploadFileRemoteOperation(filePath, remotePath, "image/jpg", "123", true)
                                .execute(client).isSuccess());
         }
 

--- a/src/main/java/com/owncloud/android/lib/resources/files/UploadFileRemoteOperation.java
+++ b/src/main/java/com/owncloud/android/lib/resources/files/UploadFileRemoteOperation.java
@@ -61,6 +61,7 @@ public class UploadFileRemoteOperation extends RemoteOperation {
 	protected String remotePath;
 	protected String mimeType;
 	private String lastModificationTimestamp;
+	protected final boolean disableRetries;
 	PutMethod putMethod = null;
 	private String requiredEtag = null;
     String token = null;
@@ -72,17 +73,19 @@ public class UploadFileRemoteOperation extends RemoteOperation {
 	protected RequestEntity entity = null;
 
     public UploadFileRemoteOperation(String localPath,
-                                     String remotePath,
-                                     String mimeType,
-                                     String requiredEtag,
-                                     String lastModificationTimestamp) {
-        this(localPath, remotePath, mimeType, requiredEtag, lastModificationTimestamp, null);
+									 String remotePath,
+									 String mimeType,
+									 String requiredEtag,
+									 String lastModificationTimestamp,
+									 boolean disableRetries) {
+        this(localPath, remotePath, mimeType, requiredEtag, lastModificationTimestamp, null, disableRetries);
     }
 
     public UploadFileRemoteOperation(String localPath,
-                                     String remotePath,
-                                     String mimeType,
-									 String lastModificationTimestamp) {
+									 String remotePath,
+									 String mimeType,
+									 String lastModificationTimestamp,
+									 boolean disableRetries) {
 		this.localPath = localPath;
 		this.remotePath = remotePath;
 		this.mimeType = mimeType;
@@ -94,15 +97,17 @@ public class UploadFileRemoteOperation extends RemoteOperation {
         // TODO check for max value of lastModificationTimestamp
 
 		this.lastModificationTimestamp = lastModificationTimestamp;
+        this.disableRetries = disableRetries;
 	}
 
     public UploadFileRemoteOperation(String localPath,
-                                     String remotePath,
-                                     String mimeType,
-                                     String requiredEtag,
-                                     String lastModificationTimestamp,
-                                     String token) {
-		this(localPath, remotePath, mimeType, lastModificationTimestamp);
+									 String remotePath,
+									 String mimeType,
+									 String requiredEtag,
+									 String lastModificationTimestamp,
+									 String token,
+									 boolean disableRetries) {
+		this(localPath, remotePath, mimeType, lastModificationTimestamp, disableRetries);
 		this.requiredEtag = requiredEtag;
         this.token = token;
 	}
@@ -114,11 +119,11 @@ public class UploadFileRemoteOperation extends RemoteOperation {
 			(DefaultHttpMethodRetryHandler) client.getParams().getParameter(HttpMethodParams.RETRY_HANDLER);
 
 		try {
-			// prevent that uploads are retried automatically by network library
-			client.getParams().setParameter(
-				HttpMethodParams.RETRY_HANDLER,
-				new DefaultHttpMethodRetryHandler(0, false)
-			);
+			if (disableRetries) {
+				// prevent that uploads are retried automatically by network library
+				DefaultHttpMethodRetryHandler noRetryHandler = new DefaultHttpMethodRetryHandler(0, false);
+				client.getParams().setParameter(HttpMethodParams.RETRY_HANDLER, noRetryHandler);
+			}
 
 			putMethod = new PutMethod(client.getWebdavUri() + WebdavUtils.encodePath(remotePath));
 
@@ -146,11 +151,10 @@ public class UploadFileRemoteOperation extends RemoteOperation {
 				result = new RemoteOperationResult(e);
 			}
 		} finally {
-			// reset previous retry handler
-			client.getParams().setParameter(
-				HttpMethodParams.RETRY_HANDLER,
-				oldRetryHandler
-			);
+			if (disableRetries) {
+				// reset previous retry handler
+				client.getParams().setParameter(HttpMethodParams.RETRY_HANDLER, oldRetryHandler);
+			}
 		}
 		return result;
 	}

--- a/src/test/java/com/owncloud/android/lib/resources/files/ChunkedFileUploadRemoteOperationTest.java
+++ b/src/test/java/com/owncloud/android/lib/resources/files/ChunkedFileUploadRemoteOperationTest.java
@@ -146,7 +146,8 @@ public class ChunkedFileUploadRemoteOperationTest {
                                                                                     null,
                                                                                     null,
                                                                                     modificationTimestamp,
-                                                                                    false);
+                                                                                    false,
+                                                                                    true);
 
         List<Chunk> missingChunks = sut.checkMissingChunks(existingChunks, length, chunkSize);
 


### PR DESCRIPTION
The retries were disabled in 0bfc3857072 and only for upload operations. It is not clear anymore why that happens and if that is still useful. This PR at least gives us the possibility to step by step experiment with retries enabled. The first use of that will be made by the DocumentsProvider's uploads.