### PR TITLE
prefer IPV6 addresses if available

### DIFF
--- a/src/main/java/com/nextcloud/common/IPV6PreferringDNS.java
+++ b/src/main/java/com/nextcloud/common/IPV6PreferringDNS.java
@@ -1,0 +1,41 @@
+package com.nextcloud.common;
+
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import okhttp3.Dns;
+
+/**
+ * Implementation of DNS which prefers IPV6 addresses (if available) over IPV4.
+ */
+public class IPV6PreferringDNS implements Dns {
+
+        private Map<String, List<InetAddress>> cache = new HashMap<>();
+
+        @Override
+        public List<InetAddress> lookup(String hostname) throws UnknownHostException {
+            List<InetAddress> addresses = cache.get(hostname.toLowerCase(Locale.ROOT));
+
+            if (addresses != null) {
+                return addresses;
+            }
+
+            addresses = Dns.SYSTEM.lookup(hostname);
+            Collections.sort(addresses, (address1, address2) -> {
+                if(address1 instanceof Inet4Address) {
+                    return 1;
+                } else {
+                    return -1;
+                }
+            });
+            cache.put(hostname, addresses);
+
+            return addresses;
+        }
+    }

--- a/src/main/java/com/nextcloud/common/NextcloudClient.kt
+++ b/src/main/java/com/nextcloud/common/NextcloudClient.kt
@@ -61,6 +61,7 @@ class NextcloudClient(var baseUri: Uri,
         val TAG = NextcloudClient::class.java.simpleName
 
         private fun createDefaultClient(context: Context) : OkHttpClient {
+            
             val trustManager = AdvancedX509TrustManager(NetworkUtils.getKnownServersStore(context))
             val sslContext = SSLContext.getInstance("TLSv1")
             sslContext.init(null, arrayOf<TrustManager>(trustManager), null)
@@ -71,6 +72,7 @@ class NextcloudClient(var baseUri: Uri,
                     .callTimeout(DEFAULT_DATA_TIMEOUT_LONG, TimeUnit.MILLISECONDS)
                     .sslSocketFactory(sslSocketFactory, trustManager)
                     .hostnameVerifier { _: String?, _: SSLSession? -> true }
+                    .dns(IPV6PreferringDNS())
                     .build()
         }
     }

--- a/src/main/java/com/owncloud/android/lib/common/network/AdvancedSslSocketFactory.java
+++ b/src/main/java/com/owncloud/android/lib/common/network/AdvancedSslSocketFactory.java
@@ -189,18 +189,7 @@ public class AdvancedSslSocketFactory implements SecureProtocolSocketFactory {
     }
 
     private InetAddress getInetAddressForHost(String host) throws UnknownHostException {
-        InetAddress address = InetAddress.getByName(host);
-        if (address instanceof Inet6Address) {
-            InetAddress[] inetAddressArray = InetAddress.getAllByName(host);
-            for (InetAddress inetAddress : inetAddressArray) {
-                if (inetAddress instanceof Inet4Address) {
-                    address = inetAddress;
-                    break;
-                }
-            }
-        }
-
-        return address;
+        return InetAddress.getByName(host);
     }
 
     /**


### PR DESCRIPTION
I am a bit unsure if the NextcloudClient client is used.
The change that really fixes #3193 is the removal of the code in AdvancedSslSocketFactory.java which used to explicitly prefer IPV4. I'm not sure why this code existed in this form.