### PR TITLE
Switch to typed responses

### DIFF
--- a/src/androidTest/java/com/nextcloud/android/lib/resources/directediting/DirectEditingCreateFileRemoteOperationTest.java
+++ b/src/androidTest/java/com/nextcloud/android/lib/resources/directediting/DirectEditingCreateFileRemoteOperationTest.java
@@ -38,41 +38,41 @@ import static org.junit.Assert.assertTrue;
 public class DirectEditingCreateFileRemoteOperationTest extends AbstractIT {
     @Test
     public void createEmptyFile() {
-        RemoteOperationResult result = new DirectEditingCreateFileRemoteOperation("/test.md",
-                                                                                  "text",
-                "textdocument")
+        RemoteOperationResult<String> result = new DirectEditingCreateFileRemoteOperation("/test.md",
+                                                                                          "text",
+                                                                                          "textdocument")
                 .execute(client);
         assertTrue(result.isSuccess());
 
-        String url = (String) result.getSingleData();
+        String url = result.getResultData();
 
         assertFalse(url.isEmpty());
     }
 
     @Test
     public void createFileFromTemplate() {
-        RemoteOperationResult result = new DirectEditingCreateFileRemoteOperation("/test.md",
-                "text",
-                "textdocument",
-                "1")
+        RemoteOperationResult<String> result = new DirectEditingCreateFileRemoteOperation("/test.md",
+                                                                                          "text",
+                                                                                          "textdocument",
+                                                                                          "1")
                 .execute(client);
         assertTrue(result.isSuccess());
 
-        String url = (String) result.getSingleData();
+        String url = result.getResultData();
 
         assertFalse(url.isEmpty());
     }
 
     @Test
     public void createFileWithSpecialCharacterFromTemplate() {
-        RemoteOperationResult result = new DirectEditingCreateFileRemoteOperation("/あ.md",
-                "text",
-                "textdocument",
-                "1")
+        RemoteOperationResult<String> result = new DirectEditingCreateFileRemoteOperation("/あ.md",
+                                                                                          "text",
+                                                                                          "textdocument",
+                                                                                          "1")
                 .execute(client);
         assertTrue(result.isSuccess());
 
-        String url = (String) result.getSingleData();
+        String url = result.getResultData();
 
         assertFalse(url.isEmpty());
     }

--- a/src/androidTest/java/com/nextcloud/lib/resources/users/GetUserInfoRemoteOperationTest.kt
+++ b/src/androidTest/java/com/nextcloud/lib/resources/users/GetUserInfoRemoteOperationTest.kt
@@ -30,7 +30,6 @@ package com.nextcloud.lib.resources.users
 import androidx.test.platform.app.InstrumentationRegistry
 import com.owncloud.android.AbstractIT
 import com.owncloud.android.lib.common.OwnCloudBasicCredentials
-import com.owncloud.android.lib.common.UserInfo
 import com.owncloud.android.lib.resources.users.GetUserInfoRemoteOperation
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -43,7 +42,7 @@ class GetUserInfoRemoteOperationTest : AbstractIT() {
         client.credentials = OwnCloudBasicCredentials("user1", "user1")
         val userInfoResult = GetUserInfoRemoteOperation().execute(client)
         assertTrue(userInfoResult.isSuccess)
-        val userInfo = userInfoResult.data[0] as UserInfo
+        val userInfo = userInfoResult.resultData
 
         assertEquals("User One", userInfo.getDisplayName())
         assertEquals("user1", userInfo.getId())
@@ -58,7 +57,7 @@ class GetUserInfoRemoteOperationTest : AbstractIT() {
         client.credentials = OwnCloudBasicCredentials("user2", "user2")
         val userInfoResult = GetUserInfoRemoteOperation().execute(client)
         assertTrue(userInfoResult.isSuccess)
-        val userInfo = userInfoResult.data[0] as UserInfo
+        val userInfo = userInfoResult.resultData
 
         assertEquals("User Two", userInfo.getDisplayName())
         assertEquals("user2", userInfo.getId())

--- a/src/androidTest/java/com/owncloud/android/lib/common/operations/GetUserQuotaTest.java
+++ b/src/androidTest/java/com/owncloud/android/lib/common/operations/GetUserQuotaTest.java
@@ -45,11 +45,10 @@ public class GetUserQuotaTest extends AbstractIT {
 
     @Test
     public void testGetUserQuota() {
-        RemoteOperationResult result = new GetUserInfoRemoteOperation().execute(client);
+        RemoteOperationResult<UserInfo> result = new GetUserInfoRemoteOperation().execute(client);
         assertTrue(result.isSuccess());
-        assertTrue(result.getData() != null && result.getData().size() == 1);
 
-        UserInfo userInfo = (UserInfo) result.getData().get(0);
+        UserInfo userInfo = result.getResultData();
         Quota quota = userInfo.getQuota();
         assertTrue(quota.getFree() >= 0);
         assertTrue(quota.getUsed() >= 0);

--- a/src/androidTest/java/com/owncloud/android/lib/resources/users/SetUserInfoRemoteOperationTest.java
+++ b/src/androidTest/java/com/owncloud/android/lib/resources/users/SetUserInfoRemoteOperationTest.java
@@ -42,9 +42,9 @@ import static org.junit.Assert.assertTrue;
 public class SetUserInfoRemoteOperationTest extends AbstractIT {
     @Test
     public void testSetEmail() {
-        RemoteOperationResult userInfo = new GetUserInfoRemoteOperation().execute(client);
+        RemoteOperationResult<UserInfo> userInfo = new GetUserInfoRemoteOperation().execute(client);
         assertTrue(userInfo.isSuccess());
-        String oldValue = ((UserInfo) userInfo.getData().get(0)).getEmail();
+        String oldValue = userInfo.getResultData().getEmail();
 
         // set
         assertTrue(new SetUserInfoRemoteOperation(SetUserInfoRemoteOperation.Field.EMAIL, "new@mail.com")
@@ -52,7 +52,7 @@ public class SetUserInfoRemoteOperationTest extends AbstractIT {
 
         userInfo = new GetUserInfoRemoteOperation().execute(client);
         assertTrue(userInfo.isSuccess());
-        assertEquals("new@mail.com", ((UserInfo) userInfo.getData().get(0)).email);
+        assertEquals("new@mail.com", userInfo.getResultData().email);
 
         // reset
         assertTrue(new SetUserInfoRemoteOperation(SetUserInfoRemoteOperation.Field.EMAIL, oldValue)
@@ -61,11 +61,11 @@ public class SetUserInfoRemoteOperationTest extends AbstractIT {
 
     @Test
     public void testSetDisplayName() {
-        RemoteOperationResult userInfo = new GetUserInfoRemoteOperation().execute(client);
+        RemoteOperationResult<UserInfo> userInfo = new GetUserInfoRemoteOperation().execute(client);
         assertTrue(userInfo.isSuccess());
 
         String oldUserId = client.getUserId();
-        assertEquals(client.getUserId(), ((UserInfo) userInfo.getData().get(0)).displayName);
+        assertEquals(client.getUserId(), userInfo.getResultData().displayName);
 
         // set display name
         assertTrue(new SetUserInfoRemoteOperation(SetUserInfoRemoteOperation.Field.DISPLAYNAME, "newName")
@@ -73,7 +73,7 @@ public class SetUserInfoRemoteOperationTest extends AbstractIT {
 
         userInfo = new GetUserInfoRemoteOperation().execute(client);
         assertTrue(userInfo.isSuccess());
-        assertEquals("newName", ((UserInfo) userInfo.getData().get(0)).displayName);
+        assertEquals("newName", userInfo.getResultData().displayName);
 
         // reset
         assertTrue(new SetUserInfoRemoteOperation(SetUserInfoRemoteOperation.Field.DISPLAYNAME, oldUserId)
@@ -86,9 +86,9 @@ public class SetUserInfoRemoteOperationTest extends AbstractIT {
         assertTrue(result.isSuccess());
         OCCapability ocCapability = (OCCapability) result.getSingleData();
 
-        RemoteOperationResult userInfo = new GetUserInfoRemoteOperation().execute(client);
+        RemoteOperationResult<UserInfo> userInfo = new GetUserInfoRemoteOperation().execute(client);
         assertTrue(userInfo.isSuccess());
-        String oldValue = ((UserInfo) userInfo.getData().get(0)).phone;
+        String oldValue = userInfo.getResultData().phone;
 
         // set
         assertTrue(new SetUserInfoRemoteOperation(SetUserInfoRemoteOperation.Field.PHONE, "+49555-12345")
@@ -98,9 +98,9 @@ public class SetUserInfoRemoteOperationTest extends AbstractIT {
         assertTrue(userInfo.isSuccess());
         
         if (ocCapability.getVersion().isNewerOrEqual(NextcloudVersion.nextcloud_21)) {
-            assertEquals("+4955512345", ((UserInfo) userInfo.getData().get(0)).phone);
+            assertEquals("+4955512345", userInfo.getResultData().phone);
         } else {
-            assertEquals("+49555-12345", ((UserInfo) userInfo.getData().get(0)).phone);
+            assertEquals("+49555-12345", userInfo.getResultData().phone);
         }
 
         // reset
@@ -110,9 +110,9 @@ public class SetUserInfoRemoteOperationTest extends AbstractIT {
 
     @Test
     public void testSetAddress() {
-        RemoteOperationResult userInfo = new GetUserInfoRemoteOperation().execute(client);
+        RemoteOperationResult<UserInfo> userInfo = new GetUserInfoRemoteOperation().execute(client);
         assertTrue(userInfo.isSuccess());
-        String oldValue = ((UserInfo) userInfo.getData().get(0)).address;
+        String oldValue = userInfo.getResultData().address;
 
         // set
         assertTrue(new SetUserInfoRemoteOperation(SetUserInfoRemoteOperation.Field.ADDRESS, "NoName Street 123")
@@ -120,7 +120,7 @@ public class SetUserInfoRemoteOperationTest extends AbstractIT {
 
         userInfo = new GetUserInfoRemoteOperation().execute(client);
         assertTrue(userInfo.isSuccess());
-        assertEquals("NoName Street 123", ((UserInfo) userInfo.getData().get(0)).address);
+        assertEquals("NoName Street 123", userInfo.getResultData().address);
 
         // reset
         assertTrue(new SetUserInfoRemoteOperation(SetUserInfoRemoteOperation.Field.ADDRESS, oldValue)
@@ -129,9 +129,9 @@ public class SetUserInfoRemoteOperationTest extends AbstractIT {
 
     @Test
     public void testSetWebsite() {
-        RemoteOperationResult userInfo = new GetUserInfoRemoteOperation().execute(client);
+        RemoteOperationResult<UserInfo> userInfo = new GetUserInfoRemoteOperation().execute(client);
         assertTrue(userInfo.isSuccess());
-        String oldValue = ((UserInfo) userInfo.getData().get(0)).website;
+        String oldValue = userInfo.getResultData().website;
 
         // set
         assertTrue(new SetUserInfoRemoteOperation(SetUserInfoRemoteOperation.Field.WEBSITE, "https://nextcloud.com")
@@ -139,7 +139,7 @@ public class SetUserInfoRemoteOperationTest extends AbstractIT {
 
         userInfo = new GetUserInfoRemoteOperation().execute(client);
         assertTrue(userInfo.isSuccess());
-        assertEquals("https://nextcloud.com", ((UserInfo) userInfo.getData().get(0)).website);
+        assertEquals("https://nextcloud.com", userInfo.getResultData().website);
 
         // reset
         assertTrue(new SetUserInfoRemoteOperation(SetUserInfoRemoteOperation.Field.WEBSITE, oldValue)
@@ -148,9 +148,9 @@ public class SetUserInfoRemoteOperationTest extends AbstractIT {
 
     @Test
     public void testSetTwitter() {
-        RemoteOperationResult userInfo = new GetUserInfoRemoteOperation().execute(client);
+        RemoteOperationResult<UserInfo> userInfo = new GetUserInfoRemoteOperation().execute(client);
         assertTrue(userInfo.isSuccess());
-        String oldValue = ((UserInfo) userInfo.getData().get(0)).twitter;
+        String oldValue = userInfo.getResultData().twitter;
 
         // set
         assertTrue(new SetUserInfoRemoteOperation(SetUserInfoRemoteOperation.Field.TWITTER, "@Nextclouders")
@@ -158,7 +158,7 @@ public class SetUserInfoRemoteOperationTest extends AbstractIT {
 
         userInfo = new GetUserInfoRemoteOperation().execute(client);
         assertTrue(userInfo.isSuccess());
-        assertEquals("@Nextclouders", ((UserInfo) userInfo.getData().get(0)).twitter);
+        assertEquals("@Nextclouders", userInfo.getResultData().twitter);
 
         // reset
         assertTrue(new SetUserInfoRemoteOperation(SetUserInfoRemoteOperation.Field.TWITTER, oldValue)

--- a/src/androidTest/java/com/owncloud/android/lib/resources/users/StatusIT.kt
+++ b/src/androidTest/java/com/owncloud/android/lib/resources/users/StatusIT.kt
@@ -51,7 +51,7 @@ class StatusIT : AbstractIT() {
         val result = GetStatusRemoteOperation().run(nextcloudClient)
         assertTrue("GetStatusRemoteOperation failed: " + result.logMessage, result.isSuccess)
 
-        val status = result.singleData as Status
+        val status = result.resultData
         assertTrue(status.message.isNullOrBlank())
     }
 
@@ -71,7 +71,7 @@ class StatusIT : AbstractIT() {
             result1 = GetStatusRemoteOperation().run(nextcloudClient)
             assertTrue("GetStatusRemoteOperation failed: " + result1.logMessage, result1.isSuccess)
 
-            val status = result1.singleData as Status
+            val status = result1.resultData
             assertEquals(statusType, status.status)
         }
 
@@ -89,8 +89,7 @@ class StatusIT : AbstractIT() {
             result.isSuccess
         )
 
-        val statusesList: ArrayList<PredefinedStatus> =
-            result.singleData as ArrayList<PredefinedStatus>
+        val statusesList = result.resultData
         assertTrue(statusesList.isNotEmpty())
     }
 
@@ -116,8 +115,7 @@ class StatusIT : AbstractIT() {
             result.isSuccess
         )
 
-        val statusesList: ArrayList<PredefinedStatus> =
-            result.singleData as ArrayList<PredefinedStatus>
+        val statusesList: ArrayList<PredefinedStatus> = result.resultData
         val newCustomStatusMessage = statusesList[2]
         val clearAt = System.currentTimeMillis() / SECOND_IN_MILLIS + HOUR_IN_MINUTES
 
@@ -129,10 +127,10 @@ class StatusIT : AbstractIT() {
         )
 
         // verify
-        result = GetStatusRemoteOperation().run(nextcloudClient)
-        assertTrue("GetStatusRemoteOperation failed: " + result.logMessage, result.isSuccess)
+        val newResult = GetStatusRemoteOperation().run(nextcloudClient)
+        assertTrue("GetStatusRemoteOperation failed: " + newResult.logMessage, newResult.isSuccess)
 
-        val status = result.singleData as Status
+        val status = newResult.resultData
         assertEquals(newCustomStatusMessage.message, status.message)
     }
 
@@ -156,7 +154,7 @@ class StatusIT : AbstractIT() {
         result = GetStatusRemoteOperation().run(nextcloudClient)
         assertTrue("GetStatusRemoteOperation failed: " + result.logMessage, result.isSuccess)
 
-        val status = result.singleData as Status
+        val status = result.resultData
         assertEquals(message, status.message)
         assertEquals(statusIcon, status.icon)
         assertEquals(clearAt, status.clearAt)

--- a/src/main/java/com/nextcloud/android/lib/resources/directediting/DirectEditingCreateFileRemoteOperation.java
+++ b/src/main/java/com/nextcloud/android/lib/resources/directediting/DirectEditingCreateFileRemoteOperation.java
@@ -43,7 +43,7 @@ import lombok.AllArgsConstructor;
  */
 
 @AllArgsConstructor
-public class DirectEditingCreateFileRemoteOperation extends RemoteOperation {
+public class DirectEditingCreateFileRemoteOperation extends RemoteOperation<String> {
     private static final String TAG = DirectEditingCreateFileRemoteOperation.class.getSimpleName();
     private static final int SYNC_READ_TIMEOUT = 40000;
     private static final int SYNC_CONNECTION_TIMEOUT = 5000;
@@ -60,8 +60,8 @@ public class DirectEditingCreateFileRemoteOperation extends RemoteOperation {
         this(path, editor, creator, "");
     }
 
-    protected RemoteOperationResult run(OwnCloudClient client) {
-        RemoteOperationResult result;
+    protected RemoteOperationResult<String> run(OwnCloudClient client) {
+        RemoteOperationResult<String> result;
         Utf8PostMethod postMethod = null;
 
         try {
@@ -86,14 +86,14 @@ public class DirectEditingCreateFileRemoteOperation extends RemoteOperation {
                 JSONObject respJSON = new JSONObject(response);
                 String url = (String) respJSON.getJSONObject("ocs").getJSONObject("data").get("url");
 
-                result = new RemoteOperationResult(true, postMethod);
-                result.setSingleData(url);
+                result = new RemoteOperationResult<>(true, postMethod);
+                result.setResultData(url);
             } else {
-                result = new RemoteOperationResult(false, postMethod);
+                result = new RemoteOperationResult<>(false, postMethod);
                 client.exhaustResponse(postMethod.getResponseBodyAsStream());
             }
         } catch (Exception e) {
-            result = new RemoteOperationResult(e);
+            result = new RemoteOperationResult<>(e);
             Log_OC.e(TAG, "Get all direct editing informations failed: " + result.getLogMessage(),
                      result.getException());
         } finally {

--- a/src/main/java/com/nextcloud/android/lib/resources/directediting/DirectEditingObtainListOfTemplatesRemoteOperation.java
+++ b/src/main/java/com/nextcloud/android/lib/resources/directediting/DirectEditingObtainListOfTemplatesRemoteOperation.java
@@ -45,7 +45,7 @@ import lombok.AllArgsConstructor;
  */
 
 @AllArgsConstructor
-public class DirectEditingObtainListOfTemplatesRemoteOperation extends OCSRemoteOperation {
+public class DirectEditingObtainListOfTemplatesRemoteOperation extends OCSRemoteOperation<TemplateList> {
     private static final String TAG = DirectEditingObtainListOfTemplatesRemoteOperation.class.getSimpleName();
     private static final int SYNC_READ_TIMEOUT = 40000;
     private static final int SYNC_CONNECTION_TIMEOUT = 5000;
@@ -53,11 +53,11 @@ public class DirectEditingObtainListOfTemplatesRemoteOperation extends OCSRemote
 
     private static final String JSON_FORMAT = "?format=json";
 
-    private String editor;
-    private String template;
+    private final String editor;
+    private final String template;
 
-    protected RemoteOperationResult run(OwnCloudClient client) {
-        RemoteOperationResult result;
+    protected RemoteOperationResult<TemplateList> run(OwnCloudClient client) {
+        RemoteOperationResult<TemplateList> result;
         GetMethod getMethod = null;
 
         try {
@@ -74,15 +74,15 @@ public class DirectEditingObtainListOfTemplatesRemoteOperation extends OCSRemote
                                                               })
                         .getOcs().getData();
 
-                result = new RemoteOperationResult(true, getMethod);
+                result = new RemoteOperationResult<>(true, getMethod);
                 result.setSingleData(templateList);
             } else {
-                result = new RemoteOperationResult(false, getMethod);
+                result = new RemoteOperationResult<>(false, getMethod);
                 client.exhaustResponse(getMethod.getResponseBodyAsStream());
             }
         } catch (Exception e) {
-            result = new RemoteOperationResult(e);
-            Log_OC.e(TAG, "Get all direct editing informations failed: " + result.getLogMessage(),
+            result = new RemoteOperationResult<>(e);
+            Log_OC.e(TAG, "Get all direct editing information failed: " + result.getLogMessage(),
                      result.getException());
         } finally {
             if (getMethod != null) {

--- a/src/main/java/com/nextcloud/android/lib/resources/directediting/DirectEditingObtainRemoteOperation.java
+++ b/src/main/java/com/nextcloud/android/lib/resources/directediting/DirectEditingObtainRemoteOperation.java
@@ -38,7 +38,7 @@ import org.apache.commons.httpclient.methods.GetMethod;
  * Get all editor details from direct editing
  */
 
-public class DirectEditingObtainRemoteOperation extends OCSRemoteOperation {
+public class DirectEditingObtainRemoteOperation extends OCSRemoteOperation<DirectEditing> {
     private static final String TAG = DirectEditingObtainRemoteOperation.class.getSimpleName();
     private static final int SYNC_READ_TIMEOUT = 40000;
     private static final int SYNC_CONNECTION_TIMEOUT = 5000;
@@ -46,8 +46,8 @@ public class DirectEditingObtainRemoteOperation extends OCSRemoteOperation {
 
     private static final String JSON_FORMAT = "?format=json";
 
-    protected RemoteOperationResult run(OwnCloudClient client) {
-        RemoteOperationResult result;
+    protected RemoteOperationResult<DirectEditing> run(OwnCloudClient client) {
+        RemoteOperationResult<DirectEditing> result;
         GetMethod getMethod = null;
 
         try {
@@ -64,16 +64,16 @@ public class DirectEditingObtainRemoteOperation extends OCSRemoteOperation {
                         })
                         .getOcs().getData();
 
-                result = new RemoteOperationResult(true, getMethod);
+                result = new RemoteOperationResult<>(true, getMethod);
                 result.setSingleData(directEditing);
             } else {
-                result = new RemoteOperationResult(false, getMethod);
+                result = new RemoteOperationResult<>(false, getMethod);
                 client.exhaustResponse(getMethod.getResponseBodyAsStream());
             }
         } catch (Exception e) {
-            result = new RemoteOperationResult(e);
+            result = new RemoteOperationResult<>(e);
             Log_OC.e(TAG, "Get all direct editing informations failed: " + result.getLogMessage(),
-                    result.getException());
+                     result.getException());
         } finally {
             if (getMethod != null) {
                 getMethod.releaseConnection();

--- a/src/main/java/com/nextcloud/common/NextcloudClient.kt
+++ b/src/main/java/com/nextcloud/common/NextcloudClient.kt
@@ -77,10 +77,14 @@ class NextcloudClient(
         }
     }
 
-    constructor(baseUri: Uri, userId: String, credentials: String, context: Context) :
-        this(baseUri, userId, credentials, createDefaultClient(context))
+    constructor(
+        baseUri: Uri,
+        userId: String,
+        credentials: String,
+        context: Context
+    ) : this(baseUri, userId, credentials, createDefaultClient(context))
 
-    fun execute(remoteOperation: RemoteOperation): RemoteOperationResult {
+    fun <T> execute(remoteOperation: RemoteOperation<T>): RemoteOperationResult<T> {
         return try {
             remoteOperation.run(this)
         } catch (ex: Exception) {

--- a/src/main/java/com/owncloud/android/lib/common/operations/RemoteOperationResult.java
+++ b/src/main/java/com/owncloud/android/lib/common/operations/RemoteOperationResult.java
@@ -68,14 +68,13 @@ import okhttp3.Headers;
 
 /**
  * The result of a remote operation required to an ownCloud server.
- *
- * Provides a common classification of remote operation results for all the
- * application.
+ * <p>
+ * Provides a common classification of remote operation results for all the application.
  *
  * @author David A. Velasco
  */
 @ToString
-public class RemoteOperationResult implements Serializable {
+public class RemoteOperationResult<T extends Object> implements Serializable {
 
     // Generated - should be refreshed every time the class changes!!
     private static final long serialVersionUID = -1909603208238358633L;
@@ -154,8 +153,12 @@ public class RemoteOperationResult implements Serializable {
     @ToString.Exclude private ArrayList<String> mAuthenticateHeaders = new ArrayList<>();
     @ToString.Exclude private String mLastPermanentLocation = null;
 
-    @ToString.Exclude private ArrayList<Object> mData;
-    @ToString.Exclude private List<Notification> mNotificationData;
+    @ToString.Exclude
+    private ArrayList<Object> mData;
+    @ToString.Exclude
+    private T resultData;
+    @ToString.Exclude
+    private List<Notification> mNotificationData;
     @ToString.Exclude private PushResponse mPushResponse;
 
     /**
@@ -475,14 +478,37 @@ public class RemoteOperationResult implements Serializable {
         }
     }
 
+    /**
+     * @deprecated use setResultData() instead
+     */
+    @Deprecated
     public void setData(ArrayList<Object> files) {
         mData = files;
     }
 
+    /**
+     * @deprecated use setResultData() instead
+     */
+    @Deprecated
     public void setSingleData(Object object) {
         mData = new ArrayList<>(Collections.singletonList(object));
     }
 
+    public void setResultData(T object) {
+        resultData = object;
+    }
+
+    public T getResultData() {
+        if (!mSuccess) {
+            throw new RuntimeException("Accessing result data after operation failed!");
+        }
+        return resultData;
+    }
+
+    /**
+     * @deprecated use getResultData() instead
+     */
+    @Deprecated
     public ArrayList<Object> getData() {
         if (!mSuccess) {
             throw new RuntimeException("Accessing result data after operation failed!");
@@ -490,6 +516,10 @@ public class RemoteOperationResult implements Serializable {
         return mData;
     }
 
+    /**
+     * @deprecated use getResultData() instead
+     */
+    @Deprecated
     public Object getSingleData() {
         if (!mSuccess) {
             throw new RuntimeException("Accessing result data after operation failed!");
@@ -497,20 +527,33 @@ public class RemoteOperationResult implements Serializable {
         return mData.get(0);
     }
 
+    /**
+     * @deprecated use getResultData() instead
+     */
     public void setNotificationData(List<Notification> notifications) {
         mNotificationData = notifications;
     }
 
+    /**
+     * @deprecated use getResultData() instead
+     */
     public PushResponse getPushResponseData() {
         if (!mSuccess) {
             throw new RuntimeException("Accessing result data after operation failed!");
         }
         return mPushResponse;
     }
+
+    /**
+     * @deprecated use getResultData() instead
+     */
     public void setPushResponseData(PushResponse pushResponseData) {
         mPushResponse = pushResponseData;
     }
 
+    /**
+     * @deprecated use getResultData() instead
+     */
     public List<Notification> getNotificationData() {
         if (!mSuccess) {
             throw new RuntimeException("Accessing result data after operation failed!");

--- a/src/main/java/com/owncloud/android/lib/resources/OCSRemoteOperation.java
+++ b/src/main/java/com/owncloud/android/lib/resources/OCSRemoteOperation.java
@@ -39,12 +39,11 @@ import org.apache.commons.httpclient.HttpMethodBase;
 import java.io.IOException;
 
 /**
- *
  * Base class for OCS remote operations with convenient methods
  *
  * @author Bartosz Przybylski
  */
-public abstract class OCSRemoteOperation extends RemoteOperation {
+public abstract class OCSRemoteOperation<T> extends RemoteOperation<T> {
 
     @Deprecated
     public <T> T getServerResponse(HttpMethodBase method, TypeToken<T> type) throws IOException {

--- a/src/main/java/com/owncloud/android/lib/resources/users/GetPredefinedStatusesRemoteOperation.java
+++ b/src/main/java/com/owncloud/android/lib/resources/users/GetPredefinedStatusesRemoteOperation.java
@@ -42,7 +42,7 @@ import java.util.ArrayList;
 /**
  * Remote operation to get all predefined statuses
  */
-public class GetPredefinedStatusesRemoteOperation extends OCSRemoteOperation {
+public class GetPredefinedStatusesRemoteOperation extends OCSRemoteOperation<ArrayList<PredefinedStatus>> {
     private static final String TAG = GetPredefinedStatusesRemoteOperation.class.getSimpleName();
     private static final String GET_STATUS_URL = "/ocs/v2.php/apps/user_status/api/v1/predefined_statuses";
 
@@ -52,9 +52,9 @@ public class GetPredefinedStatusesRemoteOperation extends OCSRemoteOperation {
      * @param client Client object
      */
     @Override
-    public RemoteOperationResult run(NextcloudClient client) {
+    public RemoteOperationResult<ArrayList<PredefinedStatus>> run(NextcloudClient client) {
         GetMethod getMethod = null;
-        RemoteOperationResult result;
+        RemoteOperationResult<ArrayList<PredefinedStatus>> result;
 
         try {
             // remote request
@@ -69,14 +69,14 @@ public class GetPredefinedStatusesRemoteOperation extends OCSRemoteOperation {
                                 new TypeToken<ServerResponse<ArrayList<PredefinedStatus>>>() {
                                 });
 
-                result = new RemoteOperationResult(true, getMethod);
-                result.setSingleData(serverResponse.getOcs().getData());
+                result = new RemoteOperationResult<>(true, getMethod);
+                result.setResultData(serverResponse.getOcs().getData());
             } else {
-                result = new RemoteOperationResult(false, getMethod);
+                result = new RemoteOperationResult<>(false, getMethod);
                 getMethod.releaseConnection();
             }
         } catch (Exception e) {
-            result = new RemoteOperationResult(e);
+            result = new RemoteOperationResult<>(e);
             Log_OC.e(TAG, "Fetching of predefined statuses failed: " + result.getLogMessage(), result.getException());
         } finally {
             if (getMethod != null) {

--- a/src/main/java/com/owncloud/android/lib/resources/users/GetPrivateKeyOperation.java
+++ b/src/main/java/com/owncloud/android/lib/resources/users/GetPrivateKeyOperation.java
@@ -38,14 +38,12 @@ import com.owncloud.android.lib.resources.OCSRemoteOperation;
 import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.httpclient.methods.GetMethod;
 
-import java.util.ArrayList;
-
 
 /**
  * Remote operation performing the fetch of the private key for an user
  */
 
-public class GetPrivateKeyOperation extends OCSRemoteOperation {
+public class GetPrivateKeyOperation extends OCSRemoteOperation<PrivateKey> {
 
     private static final String TAG = GetPrivateKeyOperation.class.getSimpleName();
     private static final int SYNC_READ_TIMEOUT = 40000;
@@ -58,9 +56,9 @@ public class GetPrivateKeyOperation extends OCSRemoteOperation {
      * @param client Client object
      */
     @Override
-    protected RemoteOperationResult run(OwnCloudClient client) {
+    protected RemoteOperationResult<PrivateKey> run(OwnCloudClient client) {
         GetMethod getMethod = null;
-        RemoteOperationResult result;
+        RemoteOperationResult<PrivateKey> result;
 
         try {
             // remote request
@@ -70,19 +68,18 @@ public class GetPrivateKeyOperation extends OCSRemoteOperation {
             int status = client.executeMethod(getMethod, SYNC_READ_TIMEOUT, SYNC_CONNECTION_TIMEOUT);
 
             if (status == HttpStatus.SC_OK) {
-                ServerResponse<PrivateKey> serverResponse = getServerResponse(getMethod, new TypeToken<ServerResponse<PrivateKey>>(){});
+                ServerResponse<PrivateKey> serverResponse = getServerResponse(getMethod, new TypeToken<ServerResponse<PrivateKey>>() {
+                });
 
-                result = new RemoteOperationResult(true, getMethod);
-                ArrayList<Object> keys = new ArrayList<>();
-                keys.add(serverResponse.getOcs().getData().getKey());
-                result.setData(keys);
+                result = new RemoteOperationResult<>(true, getMethod);
+                result.setSingleData(serverResponse.getOcs().data);
             } else {
-                result = new RemoteOperationResult(false, getMethod);
+                result = new RemoteOperationResult<>(false, getMethod);
                 client.exhaustResponse(getMethod.getResponseBodyAsStream());
             }
 
         } catch (Exception e) {
-            result = new RemoteOperationResult(e);
+            result = new RemoteOperationResult<>(e);
             Log_OC.e(TAG, "Fetching of public key failed: " + result.getLogMessage(), result.getException());
         } finally {
             if (getMethod != null)

--- a/src/main/java/com/owncloud/android/lib/resources/users/GetStatusRemoteOperation.java
+++ b/src/main/java/com/owncloud/android/lib/resources/users/GetStatusRemoteOperation.java
@@ -40,7 +40,7 @@ import org.apache.commons.httpclient.HttpStatus;
 /**
  * Remote operation to get status
  */
-public class GetStatusRemoteOperation extends OCSRemoteOperation {
+public class GetStatusRemoteOperation extends OCSRemoteOperation<Status> {
 
     private static final String TAG = GetStatusRemoteOperation.class.getSimpleName();
     private static final String GET_STATUS_URL = "/ocs/v2.php/apps/user_status/api/v1/user_status";
@@ -50,9 +50,9 @@ public class GetStatusRemoteOperation extends OCSRemoteOperation {
      * @param client Client object
      */
     @Override
-    public RemoteOperationResult run(NextcloudClient client) {
+    public RemoteOperationResult<Status> run(NextcloudClient client) {
         GetMethod getMethod = null;
-        RemoteOperationResult result;
+        RemoteOperationResult<Status> result;
 
         try {
             // remote request
@@ -66,20 +66,20 @@ public class GetStatusRemoteOperation extends OCSRemoteOperation {
                         new TypeToken<ServerResponse<Status>>() {
                         });
 
-                result = new RemoteOperationResult(true, getMethod);
-                result.setSingleData(serverResponse.getOcs().getData());
+                result = new RemoteOperationResult<>(true, getMethod);
+                result.setResultData(serverResponse.getOcs().getData());
             } else {
                 // 404 if no status was set before
                 if (HttpStatus.SC_NOT_FOUND == getMethod.getStatusCode()) {
-                    result = new RemoteOperationResult(true, getMethod);
-                    result.setSingleData(new Status(StatusType.INVISIBLE, "", "", -1));
+                    result = new RemoteOperationResult<>(true, getMethod);
+                    result.setResultData(new Status(StatusType.INVISIBLE, "", "", -1));
                 } else {
-                    result = new RemoteOperationResult(false, getMethod);
+                    result = new RemoteOperationResult<>(false, getMethod);
                     getMethod.releaseConnection();
                 }
             }
         } catch (Exception e) {
-            result = new RemoteOperationResult(e);
+            result = new RemoteOperationResult<>(e);
             Log_OC.e(TAG, "Fetching of own status failed: " + result.getLogMessage(), result.getException());
         } finally {
             if (getMethod != null) {

--- a/src/main/java/com/owncloud/android/lib/resources/users/GetUserInfoRemoteOperation.java
+++ b/src/main/java/com/owncloud/android/lib/resources/users/GetUserInfoRemoteOperation.java
@@ -40,8 +40,6 @@ import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.httpclient.NameValuePair;
 import org.apache.commons.httpclient.methods.GetMethod;
 
-import java.util.ArrayList;
-
 /**
  * Gets information (id, display name, and e-mail address and many other things) about the user logged in.
  *
@@ -49,7 +47,7 @@ import java.util.ArrayList;
  * @author David A. Velasco
  * @author Mario Danic
  */
-public class GetUserInfoRemoteOperation extends OCSRemoteOperation {
+public class GetUserInfoRemoteOperation extends OCSRemoteOperation<UserInfo> {
 
     private static final String TAG = GetUserInfoRemoteOperation.class.getSimpleName();
 
@@ -77,8 +75,8 @@ public class GetUserInfoRemoteOperation extends OCSRemoteOperation {
     public static final long QUOTA_LIMIT_INFO_NOT_AVAILABLE = Long.MIN_VALUE;
 
     @Override
-    protected RemoteOperationResult run(OwnCloudClient client) {
-        RemoteOperationResult result;
+    protected RemoteOperationResult<UserInfo> run(OwnCloudClient client) {
+        RemoteOperationResult<UserInfo> result;
         int status;
         GetMethod get = null;
 
@@ -107,13 +105,10 @@ public class GetUserInfoRemoteOperation extends OCSRemoteOperation {
                     userInfo.getQuota().setQuota(QUOTA_LIMIT_INFO_NOT_AVAILABLE);
                 }
 
-                result = new RemoteOperationResult(true, get);
-                // Username in result.data
-                ArrayList<Object> data = new ArrayList<>();
-                data.add(userInfo);
-                result.setData(data);
+                result = new RemoteOperationResult<>(true, get);
+                result.setResultData(userInfo);
             } else {
-                result = new RemoteOperationResult(false, get);
+                result = new RemoteOperationResult<>(false, get);
                 String response = get.getResponseBodyAsString();
                 Log_OC.e(TAG, "Failed response while getting user information ");
                 if (response != null) {
@@ -123,7 +118,7 @@ public class GetUserInfoRemoteOperation extends OCSRemoteOperation {
                 }
             }
         } catch (Exception e) {
-            result = new RemoteOperationResult(e);
+            result = new RemoteOperationResult<>(e);
             Log_OC.e(TAG, "Exception while getting OC user information", e);
         } finally {
             if (get != null) {

--- a/src/main/java/com/owncloud/android/lib/resources/users/SetPredefinedCustomStatusMessageRemoteOperation.java
+++ b/src/main/java/com/owncloud/android/lib/resources/users/SetPredefinedCustomStatusMessageRemoteOperation.java
@@ -35,13 +35,15 @@ import com.owncloud.android.lib.resources.OCSRemoteOperation;
 
 import org.apache.commons.httpclient.HttpStatus;
 
+import java.util.ArrayList;
+
 import okhttp3.MediaType;
 import okhttp3.RequestBody;
 
 /**
  * Remote operation performing setting of predefined custome status message
  */
-public class SetPredefinedCustomStatusMessageRemoteOperation extends OCSRemoteOperation {
+public class SetPredefinedCustomStatusMessageRemoteOperation extends OCSRemoteOperation<ArrayList<PredefinedStatus>> {
 
     private static final String TAG = SetPredefinedCustomStatusMessageRemoteOperation.class.getSimpleName();
     private static final String SET_STATUS_URL = "/ocs/v2.php/apps/user_status/api/v1/user_status/message/predefined";
@@ -58,9 +60,9 @@ public class SetPredefinedCustomStatusMessageRemoteOperation extends OCSRemoteOp
      * @param client Client object
      */
     @Override
-    public RemoteOperationResult run(NextcloudClient client) {
+    public RemoteOperationResult<ArrayList<PredefinedStatus>> run(NextcloudClient client) {
         PutMethod putMethod = null;
-        RemoteOperationResult result;
+        RemoteOperationResult<ArrayList<PredefinedStatus>> result;
 
         try {
             // request body
@@ -75,13 +77,13 @@ public class SetPredefinedCustomStatusMessageRemoteOperation extends OCSRemoteOp
             int status = client.execute(putMethod);
 
             if (status == HttpStatus.SC_OK) {
-                result = new RemoteOperationResult(true, putMethod);
+                result = new RemoteOperationResult<>(true, putMethod);
             } else {
-                result = new RemoteOperationResult(false, putMethod);
+                result = new RemoteOperationResult<>(false, putMethod);
                 putMethod.releaseConnection();
             }
         } catch (Exception e) {
-            result = new RemoteOperationResult(e);
+            result = new RemoteOperationResult<>(e);
             Log_OC.e(TAG, "Setting of predefined custom status failed: " + result.getLogMessage(),
                     result.getException());
         } finally {

--- a/src/main/java/com/owncloud/android/lib/resources/users/SetStatusRemoteOperation.java
+++ b/src/main/java/com/owncloud/android/lib/resources/users/SetStatusRemoteOperation.java
@@ -41,7 +41,7 @@ import okhttp3.RequestBody;
 /**
  * Remote operation performing setting of status
  */
-public class SetStatusRemoteOperation extends OCSRemoteOperation {
+public class SetStatusRemoteOperation extends OCSRemoteOperation<com.owncloud.android.lib.resources.users.Status> {
 
     private static final String TAG = SetStatusRemoteOperation.class.getSimpleName();
     private static final String SET_STATUS_URL = "/ocs/v2.php/apps/user_status/api/v1/user_status/status";
@@ -56,9 +56,9 @@ public class SetStatusRemoteOperation extends OCSRemoteOperation {
      * @param client Client object
      */
     @Override
-    public RemoteOperationResult run(NextcloudClient client) {
+    public RemoteOperationResult<com.owncloud.android.lib.resources.users.Status> run(NextcloudClient client) {
         PutMethod putMethod = null;
-        RemoteOperationResult result;
+        RemoteOperationResult<com.owncloud.android.lib.resources.users.Status> result;
 
         try {
             // request body
@@ -71,13 +71,13 @@ public class SetStatusRemoteOperation extends OCSRemoteOperation {
             int status = client.execute(putMethod);
 
             if (status == HttpStatus.SC_OK) {
-                result = new RemoteOperationResult(true, putMethod);
+                result = new RemoteOperationResult<>(true, putMethod);
             } else {
-                result = new RemoteOperationResult(false, putMethod);
+                result = new RemoteOperationResult<>(false, putMethod);
                 putMethod.releaseConnection();
             }
         } catch (Exception e) {
-            result = new RemoteOperationResult(e);
+            result = new RemoteOperationResult<>(e);
             Log_OC.e(TAG, "Setting of own status failed: " + result.getLogMessage(), result.getException());
         } finally {
             if (putMethod != null) {

--- a/src/test/java/com/nextcloud/common/NextcloudClientTest.kt
+++ b/src/test/java/com/nextcloud/common/NextcloudClientTest.kt
@@ -73,8 +73,8 @@ class NextcloudClientTest {
         //      failing operations
         //      operations throws any kind of exception
         val exception = RuntimeException("test exception")
-        val operation = object : RemoteOperation() {
-            override fun run(client: NextcloudClient?): RemoteOperationResult {
+        val operation = object : RemoteOperation<String>() {
+            override fun run(client: NextcloudClient?): RemoteOperationResult<String> {
                 throw exception
             }
         }


### PR DESCRIPTION
This is just an idea to see how it might work:
- RemoteOperationResult is now typed
- [x] marked as deprecated RemoteOperationResult
  -  getSingleData
  - getNotificationData
  - getPushResponseData

With this we can directly use it on client side, do not need to cast it, and are type safe.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>