### PR TITLE
Revert "Bump dav4jvm from 1.0.1 to 2.1.2"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ ext {
 dependencies {
     implementation 'org.apache.jackrabbit:jackrabbit-webdav:2.13.1'
     api 'com.squareup.okhttp3:okhttp:3.12.6' // >= 3.13 requires Android 5 (API 21)
-    implementation 'com.gitlab.bitfireAT:dav4jvm:2.1.2' // in transition phase, we use old and new libs
+    implementation 'com.gitlab.bitfireAT:dav4jvm:1.0.1' // in transition phase, we use old and new libs
     implementation 'org.parceler:parceler-api:1.1.13'
     annotationProcessor 'org.parceler:parceler:1.1.13'
     implementation group: 'com.google.code.gson', name: 'gson', version: '2.8.6'


### PR DESCRIPTION
We still need 1.x as we support Android < 5

Reverts nextcloud/android-library#540