### PR TITLE
Remove snapshot repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,9 +7,6 @@ buildscript {
         google()
         jcenter()
         maven {
-            url 'https://oss.sonatype.org/content/repositories/snapshots/'
-        }
-        maven {
             url 'https://plugins.gradle.org/m2/'
         }
         mavenCentral()
@@ -36,7 +33,6 @@ repositories {
     google()
     jcenter()
     maven { url "https://jitpack.io" }
-    maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
 
     flatDir {
         dirs 'libs'


### PR DESCRIPTION
Using snapshots caused https://github.com/nextcloud/android/issues/7699.

Looking into git this was just copied from client on moving tests: 7309b3451a81fec23449db7cfe0b5c63ff033033

On client snapshots were introduced for evernote:android-job https://github.com/nextcloud/android/commit/140f2d9b7bbad3a60910daf2faf83acd35fe2a32#diff-49a96e7eea8a94af862798a45174e6ac43eb4f8b4bd40759b5da63ba31ec3ef7 which is no longer a dep. Will remove it from there too.
