### PR TITLE
Switch set user info to ocs V2

### DIFF
--- a/src/androidTest/java/com/owncloud/android/lib/resources/users/SetUserInfoRemoteOperationTest.java
+++ b/src/androidTest/java/com/owncloud/android/lib/resources/users/SetUserInfoRemoteOperationTest.java
@@ -84,12 +84,12 @@ public class SetUserInfoRemoteOperationTest extends AbstractIT {
         String oldValue = ((UserInfo) userInfo.getData().get(0)).phone;
 
         // set
-        assertTrue(new SetUserInfoRemoteOperation(SetUserInfoRemoteOperation.Field.PHONE, "555-12345")
+        assertTrue(new SetUserInfoRemoteOperation(SetUserInfoRemoteOperation.Field.PHONE, "+49555-12345")
                            .execute(client).isSuccess());
 
         userInfo = new GetUserInfoRemoteOperation().execute(client);
         assertTrue(userInfo.isSuccess());
-        assertEquals("555-12345", ((UserInfo) userInfo.getData().get(0)).phone);
+        assertEquals("+4955512345", ((UserInfo) userInfo.getData().get(0)).phone);
 
         // reset
         assertTrue(new SetUserInfoRemoteOperation(SetUserInfoRemoteOperation.Field.PHONE, oldValue)

--- a/src/main/java/com/owncloud/android/lib/resources/users/SetUserInfoRemoteOperation.java
+++ b/src/main/java/com/owncloud/android/lib/resources/users/SetUserInfoRemoteOperation.java
@@ -37,7 +37,7 @@ public class SetUserInfoRemoteOperation extends RemoteOperation {
 
     private static final String TAG = SetUserInfoRemoteOperation.class.getSimpleName();
 
-    private static final String OCS_ROUTE_PATH = "/ocs/v1.php/cloud/users/";
+    private static final String OCS_ROUTE_PATH = "/ocs/v2.php/cloud/users/";
 
     public enum Field {
         EMAIL("email"),


### PR DESCRIPTION
fixed phone test: without specifying 'default_phone_region' => 'DE' in config, we have to use a valid country prefix

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>