### PR TITLE
Do not throw RuntimeException if no connection to server is possible

### DIFF
--- a/src/main/java/com/nextcloud/common/OkHttpMethodBase.kt
+++ b/src/main/java/com/nextcloud/common/OkHttpMethodBase.kt
@@ -171,7 +171,6 @@ abstract class OkHttpMethodBase(
             response = client.client.newCall(request).execute()
         } catch (ex: IOException) {
             System.out.println(ex.message)
-            throw RuntimeException(ex)
         }
 
         return response?.code ?: UNKNOWN_STATUS_CODE


### PR DESCRIPTION
Let client handle it correctly.

Fix https://github.com/nextcloud/android/issues/8082

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>