### PR TITLE
Activity: preview object now has filename

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -6,15 +6,6 @@
           <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
         </value>
       </option>
-      <option name="PACKAGES_IMPORT_LAYOUT">
-        <value>
-          <package name="" alias="false" withSubpackages="true" />
-          <package name="java" alias="false" withSubpackages="true" />
-          <package name="javax" alias="false" withSubpackages="true" />
-          <package name="kotlin" alias="false" withSubpackages="true" />
-          <package name="" alias="true" withSubpackages="true" />
-        </value>
-      </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />

--- a/src/main/java/com/owncloud/android/lib/resources/activities/models/PreviewObject.java
+++ b/src/main/java/com/owncloud/android/lib/resources/activities/models/PreviewObject.java
@@ -44,4 +44,5 @@ public class PreviewObject {
     private Boolean mimeTypeIcon;
     private String mimeType;
     private String view;
+    private String filename;
 }

--- a/src/main/java/com/owncloud/android/lib/resources/activities/models/PreviewObjectAdapter.java
+++ b/src/main/java/com/owncloud/android/lib/resources/activities/models/PreviewObjectAdapter.java
@@ -31,6 +31,8 @@ import com.google.gson.stream.JsonWriter;
 
 import java.io.IOException;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * PreviewList Parser
  */
@@ -59,13 +61,20 @@ public class PreviewObjectAdapter extends TypeAdapter<PreviewObject> {
         return preview;
     }
 
+    @SuppressFBWarnings(value = "SF_SWITCH_NO_DEFAULT",
+            justification = "default case is not found correctly")
     private PreviewObject readObject(JsonReader in) throws IOException {
         String tag;
         PreviewObject preview = new PreviewObject();
 
         do {
-            tag = in.nextName();
-            
+            try {
+                tag = in.nextName();
+            } catch (IllegalStateException e) {
+                in.skipValue();
+                tag = "";
+            }
+
             switch (tag) {
                 case "source":
                     preview.setSource(in.nextString());
@@ -90,6 +99,9 @@ public class PreviewObjectAdapter extends TypeAdapter<PreviewObject> {
                 case "view":
                     preview.setView(in.nextString());
                     break;
+
+                case "filename":
+                    preview.setFilename(in.nextString());
 
                 default:
                     // do nothing


### PR DESCRIPTION
made parser more robust

Introduced in https://github.com/nextcloud/activity/commit/38a31e599e0df883c517d76886af38e9babfb140#diff-76b5a357391276b282a516f54f48ef3c207f46d8192dc58c208d5183d38415f8

@nickvergessen do we really want to change api this silently?

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>