### PR TITLE
Scale read-timeout on chunk-upload file assembly

### DIFF
--- a/src/main/java/com/owncloud/android/lib/resources/files/ChunkedFileUploadRemoteOperation.java
+++ b/src/main/java/com/owncloud/android/lib/resources/files/ChunkedFileUploadRemoteOperation.java
@@ -50,6 +50,7 @@ import java.nio.channels.FileChannel;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.lang.Math;
 
 
 public class ChunkedFileUploadRemoteOperation extends UploadFileRemoteOperation {
@@ -181,7 +182,7 @@ public class ChunkedFileUploadRemoteOperation extends UploadFileRemoteOperation 
             if (token != null) {
                 moveMethod.addRequestHeader(E2E_TOKEN, token);
             }
-            int moveResult = client.executeMethod(moveMethod);
+            int moveResult = client.executeMethod(moveMethod, CalcAssembleTimeout(file), -1);
 
             result = new RemoteOperationResult(isSuccess(moveResult), moveMethod);
         } catch (Exception e) {
@@ -314,5 +315,13 @@ public class ChunkedFileUploadRemoteOperation extends UploadFileRemoteOperation 
         }
 
         return putMethod;
+    }
+
+    private int CalcAssembleTimeout(File file) {
+        final double threeMinutes = 3.0 * 60 * 1000;
+        final int thirtySeconds = 30 * 1000;
+        final int thirtyMinutes = 30 * 60 * 1000;
+        int AssembleReadTimeout = Math.max(thirtySeconds , Math.min((int)(threeMinutes * file.length() / 1e9) , thirtyMinutes) );
+        return AssembleReadTimeout;
     }
 }


### PR DESCRIPTION
This is a fix for nextcloud/android#5609 as proposed in #696. 
It works by setting the read timeout for the move-method that assembles chunk-uploads on the server to 3 minutes per GB between 30 seconds and 30 minutes, consistent with Nextcloud-dektop.