### PR TITLE
encode user id in `OwnCloudClient.getFilesDavUri(String)`

### DIFF
--- a/src/main/java/com/owncloud/android/lib/common/OwnCloudClient.java
+++ b/src/main/java/com/owncloud/android/lib/common/OwnCloudClient.java
@@ -297,7 +297,7 @@ public class OwnCloudClient extends HttpClient {
     }
     
     public String getFilesDavUri(String path) {
-        return getDavUri() + "/files/" + userId + "/" + WebdavUtils.encodePath(path);
+        return getDavUri() + "/files/" + getUserId() + "/" + WebdavUtils.encodePath(path);
     }
 
     public Uri getFilesDavUri() {


### PR DESCRIPTION
usernames containing spaces cause serious issues up to denying logins and syncs - making the whole app unusable while the same id works using the web gui.

Fixes #755