### PR TITLE
Fix username encoding in file paths

### DIFF
--- a/src/main/java/com/owncloud/android/lib/common/OwnCloudClient.java
+++ b/src/main/java/com/owncloud/android/lib/common/OwnCloudClient.java
@@ -301,7 +301,7 @@ public class OwnCloudClient extends HttpClient {
     }
 
     public Uri getFilesDavUri() {
-        return Uri.parse(getDavUri() + "/files/" + userId);
+        return Uri.parse(getDavUri() + "/files/" + getUserId());
     }
 
     public Uri getUploadUri() {

--- a/src/main/java/com/owncloud/android/lib/common/utils/WebDavFileUtils.java
+++ b/src/main/java/com/owncloud/android/lib/common/utils/WebDavFileUtils.java
@@ -61,15 +61,10 @@ public class WebDavFileUtils {
 
         if (isReadFolderOperation) {
             we = new WebdavEntry(remoteData.getResponses()[0],
-                    client.getFilesDavUri().getPath());
+                    client.getFilesDavUri().getEncodedPath());
             mFolderAndFiles.add(fillOCFile(we));
         } else {
             start = 0;
-        }
-
-        String stripString = client.getFilesDavUri().getPath();
-        if (isSearchOperation) {
-            stripString = stripString.replaceAll(" ", "%20");
         }
 
         // loop to update every child
@@ -77,7 +72,7 @@ public class WebDavFileUtils {
         MultiStatusResponse[] responses = remoteData.getResponses();
         for (int i = start; i < responses.length; i++) {
             /// new OCFile instance with the data from the server
-            we = new WebdavEntry(responses[i], stripString);
+            we = new WebdavEntry(responses[i], client.getFilesDavUri().getEncodedPath());
             remoteFile = fillOCFile(we);
             mFolderAndFiles.add(remoteFile);
         }

--- a/src/main/java/com/owncloud/android/lib/resources/files/ReadFileRemoteOperation.java
+++ b/src/main/java/com/owncloud/android/lib/resources/files/ReadFileRemoteOperation.java
@@ -91,7 +91,7 @@ public class ReadFileRemoteOperation extends RemoteOperation {
                 // Parse response
                 MultiStatus resp = propfind.getResponseBodyAsMultiStatus();
                 WebdavEntry we = new WebdavEntry(resp.getResponses()[0],
-                        client.getFilesDavUri().getPath());
+                        client.getFilesDavUri().getEncodedPath());
                 RemoteFile remoteFile = new RemoteFile(we);
                 ArrayList<Object> files = new ArrayList<Object>();
                 files.add(remoteFile);

--- a/src/main/java/com/owncloud/android/lib/resources/files/ReadFolderRemoteOperation.java
+++ b/src/main/java/com/owncloud/android/lib/resources/files/ReadFolderRemoteOperation.java
@@ -141,14 +141,14 @@ public class ReadFolderRemoteOperation extends RemoteOperation {
         mFolderAndFiles = new ArrayList<>();
 
         // parse data from remote folder 
-        WebdavEntry we = new WebdavEntry(remoteData.getResponses()[0], client.getFilesDavUri().getPath());
+        WebdavEntry we = new WebdavEntry(remoteData.getResponses()[0], client.getFilesDavUri().getEncodedPath());
         mFolderAndFiles.add(fillOCFile(we));
 
         // loop to update every child
         RemoteFile remoteFile;
         for (int i = 1; i < remoteData.getResponses().length; ++i) {
             /// new OCFile instance with the data from the server
-            we = new WebdavEntry(remoteData.getResponses()[i], client.getFilesDavUri().getPath());
+            we = new WebdavEntry(remoteData.getResponses()[i], client.getFilesDavUri().getEncodedPath());
             remoteFile = fillOCFile(we);
             mFolderAndFiles.add(remoteFile);
         }


### PR DESCRIPTION
https://github.com/nextcloud/android-library/pull/756 introduced encoding for username as an attempt to fix some issues for usernames with spaces.
However that backfired spectacularly, causing even more issues because encoding was now inconsistent throughout the code.
This fixes that.

Fixes https://github.com/nextcloud/android/issues/9331