### PR TITLE
OwnCloudClient: Do not encode @ in userIds

### DIFF
--- a/src/main/java/com/owncloud/android/lib/common/OwnCloudClient.java
+++ b/src/main/java/com/owncloud/android/lib/common/OwnCloudClient.java
@@ -60,7 +60,12 @@ public class OwnCloudClient extends HttpClient {
     private static final String PARAM_SINGLE_COOKIE_HEADER = "http.protocol.single-cookie-header";
     private static final boolean PARAM_SINGLE_COOKIE_HEADER_VALUE = true;
     private static final String PARAM_PROTOCOL_VERSION = "http.protocol.version";
-    
+    /**
+     * Characters to skip during userID encoding
+     */
+    private static final String ALLOWED_USERID_CHARACTERS = "@";
+
+
     private static byte[] sExhaustBuffer = new byte[1024];
     
     private static int sIntanceCounter = 0;
@@ -414,7 +419,7 @@ public class OwnCloudClient extends HttpClient {
      * @return uri-encoded userId
      */
     public String getUserId() {
-        return Uri.encode(userId);
+        return Uri.encode(userId, ALLOWED_USERID_CHARACTERS);
     }
 
     public String getUserIdPlain() {


### PR DESCRIPTION
Follow up to #761
Fixes https://github.com/nextcloud/android/issues/9439

Thank you @liam-p-23 for reporting