### PR TITLE
OwnCloudClient: don't encode '+' in usernames

### DIFF
--- a/src/androidTest/java/com/owncloud/android/lib/common/OwnCloudClientTest.kt
+++ b/src/androidTest/java/com/owncloud/android/lib/common/OwnCloudClientTest.kt
@@ -52,4 +52,25 @@ class OwnCloudClientTest : AbstractIT() {
             client.uploadUri
         )
     }
+
+    @Test
+    fun testUserId() {
+        val client = OwnCloudClientFactory.createOwnCloudClient(
+            Uri.parse("https://10.0.2.2/nc"),
+            context,
+            false
+        )
+
+        client.userId = "test"
+        assertEquals("Wrong encoded userId", "test", client.userId)
+
+        client.userId = "test+test@test.localhost"
+        assertEquals("Wrong encoded userId", "test+test@test.localhost", client.userId)
+
+        client.userId = "test - ab4c"
+        assertEquals("Wrong encoded userId", "test%20-%20ab4c", client.userId)
+
+        client.userId = "test.-&51_+-?@test.localhost"
+        assertEquals("Wrong encoded userId", "test.-%2651_+-%3F@test.localhost", client.userId)
+    }
 }

--- a/src/main/java/com/owncloud/android/lib/common/OwnCloudClient.java
+++ b/src/main/java/com/owncloud/android/lib/common/OwnCloudClient.java
@@ -63,7 +63,7 @@ public class OwnCloudClient extends HttpClient {
     /**
      * Characters to skip during userID encoding
      */
-    private static final String ALLOWED_USERID_CHARACTERS = "@";
+    private static final String ALLOWED_USERID_CHARACTERS = "@+";
 
 
     private static byte[] sExhaustBuffer = new byte[1024];


### PR DESCRIPTION
It's a valid character in email addresses

Fixes https://github.com/nextcloud/android/issues/9681