### PR TITLE
Workflows: use Eclipse Temurin instead of AdoptOpenJDK

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -12,7 +12,7 @@ jobs:
             -   name: Set up JDK 11
                 uses: actions/setup-java@v2
                 with:
-                    distribution: "adopt"
+                    distribution: "temurin"
                     java-version: 11
             -   name: Run analysis wrapper
                 run: |

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -15,7 +15,7 @@ jobs:
           - name: Set up JDK 11
             uses: actions/setup-java@v2
             with:
-              distribution: "adopt"
+              distribution: "temurin"
               java-version: 11
           - name: Run detekt
             run: ./gradlew detekt

--- a/.github/workflows/ktlint.yml
+++ b/.github/workflows/ktlint.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
-          distribution: "adopt"
+          distribution: "temurin"
           java-version: 11
       - name: Run ktlint
         run: ./gradlew ktlint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
-          distribution: "adopt"
+          distribution: "temurin"
           java-version: 11
       - name: Run lint
         run: ./gradlew lint


### PR DESCRIPTION
adopt is discontinued and receives no updates, temurin is the new recommended distribution