### PR TITLE
RemoteOperationResult: don't ignore authentication headers after the first one

### DIFF
--- a/src/main/java/com/owncloud/android/lib/common/operations/RemoteOperationResult.java
+++ b/src/main/java/com/owncloud/android/lib/common/operations/RemoteOperationResult.java
@@ -77,8 +77,10 @@ import okhttp3.Headers;
 public class RemoteOperationResult<T extends Object> implements Serializable {
 
     // Generated - should be refreshed every time the class changes!!
-    private static final long serialVersionUID = -1909603208238358633L;
+    private static final long serialVersionUID = -4325446958558896222L;
     private static final String TAG = RemoteOperationResult.class.getSimpleName();
+    private static final String HEADER_WWW_AUTHENTICATE = "www-authenticate";
+    private static final String HEADER_LOCATION = "location";
 
     public enum ResultCode {
         OK,
@@ -218,11 +220,10 @@ public class RemoteOperationResult<T extends Object> implements Serializable {
 
         if (headers != null) {
             for (Header header : headers) {
-                if ("location".equals(header.getName().toLowerCase(Locale.US))) {
+                if (HEADER_LOCATION.equals(header.getName().toLowerCase(Locale.US))) {
                     mRedirectedLocation = header.getValue();
-                    continue;
-                }
-                if ("www-authenticate".equals(header.getName().toLowerCase(Locale.US))) {
+
+                } else if (HEADER_WWW_AUTHENTICATE.equals(header.getName().toLowerCase(Locale.US))) {
                     mAuthenticateHeaders.add(header.getValue());
                 }
             }
@@ -377,13 +378,10 @@ public class RemoteOperationResult<T extends Object> implements Serializable {
             Header current;
             for (Header httpHeader : httpHeaders) {
                 current = httpHeader;
-                if ("location".equals(current.getName().toLowerCase(Locale.US))) {
+                if (HEADER_LOCATION.equals(current.getName().toLowerCase(Locale.US))) {
                     mRedirectedLocation = current.getValue();
-                    continue;
-                }
-                if ("www-authenticate".equals(current.getName().toLowerCase(Locale.US))) {
+                } else if (HEADER_WWW_AUTHENTICATE.equals(current.getName().toLowerCase(Locale.US))) {
                     mAuthenticateHeaders.add(current.getValue());
-                    break;
                 }
             }
         }
@@ -414,12 +412,12 @@ public class RemoteOperationResult<T extends Object> implements Serializable {
                                  Headers httpHeaders) {
         this(success, httpCode, httpPhrase);
 
-        String location = httpHeaders.get("location");
+        String location = httpHeaders.get(HEADER_LOCATION);
         if (location != null) {
             mRedirectedLocation = location;
         }
 
-        String auth = httpHeaders.get("www-authenticat");
+        String auth = httpHeaders.get(HEADER_WWW_AUTHENTICATE);
         if (auth != null) {
             mAuthenticateHeaders.add(auth);
         }

--- a/src/test/java/com/owncloud/android/lib/common/operations/RemoteOperationResultTest.kt
+++ b/src/test/java/com/owncloud/android/lib/common/operations/RemoteOperationResultTest.kt
@@ -1,0 +1,123 @@
+/*
+ * Nextcloud Android Library is available under MIT license
+ *
+ * @author Álvaro Brey Vilas
+ * Copyright (C) 2022 Álvaro Brey Vilas
+ * Copyright (C) 2022 Nextcloud GmbH
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.owncloud.android.lib.common.operations
+
+import org.apache.commons.httpclient.Header
+import org.junit.Assert
+import org.junit.Test
+
+class RemoteOperationResultTest {
+
+    companion object {
+        private val BEARER_HEADER = Header("www-authenticate", "Bearer realm=foo")
+        private val BASIC_HEADER = Header("www-authenticate", "Basic foo")
+        private val LOCATION_HEADER = Header("location", "nextcloud.localhost")
+    }
+
+    private fun genResultWithHeaders(headers: Array<Header>): RemoteOperationResult<Unit> =
+        RemoteOperationResult<Unit>(
+            false,
+            401,
+            "foo",
+            arrayOf(
+                Header("cache-control", "no cache"),
+                Header("content-encoding", "gzip"),
+                Header("server", "nextcloud.localhost")
+            ) + headers
+        )
+
+    @Test
+    fun test_multipleAuth_withLocation() {
+
+        val sut = genResultWithHeaders(
+            arrayOf(
+                BEARER_HEADER,
+                BASIC_HEADER,
+                LOCATION_HEADER
+            )
+        )
+
+        Assert.assertTrue(
+            "Missing bearer auth header",
+            sut.authenticateHeaders.any { it == BEARER_HEADER.value }
+        )
+        Assert.assertTrue(
+            "Missing basic auth header",
+            sut.authenticateHeaders.any { it == BASIC_HEADER.value }
+        )
+        Assert.assertEquals(
+            "Wrong location header",
+            LOCATION_HEADER.value,
+            sut.redirectedLocation
+        )
+    }
+
+    @Test
+    fun test_noLocation_singleAuth() {
+
+        val sut = genResultWithHeaders(
+            arrayOf(
+                BEARER_HEADER
+            )
+        )
+
+        Assert.assertEquals(
+            "Wrong auth headers length",
+            1, sut.authenticateHeaders.size
+        )
+        Assert.assertTrue(
+            "Missing bearer auth header",
+            sut.authenticateHeaders.any { it == BEARER_HEADER.value }
+        )
+        Assert.assertEquals(
+            "Wrong location header",
+            null,
+            sut.redirectedLocation
+        )
+    }
+
+    @Test
+    fun test_noAuth_location() {
+
+        val sut = genResultWithHeaders(
+            arrayOf(
+                LOCATION_HEADER
+            )
+        )
+
+        Assert.assertEquals(
+            "Wrong auth headers length",
+            0, sut.authenticateHeaders.size
+        )
+        Assert.assertEquals(
+            "Wrong location header",
+            LOCATION_HEADER.value,
+            sut.redirectedLocation
+        )
+    }
+}


### PR DESCRIPTION
This was causing auth method detection issues in the Files app after the order of headers changed, possibly due to library updates, in 3.18+.

Note: the relevant change is [removing this `break` in the constructor](https://github.com/nextcloud/android-library/pull/809/files#diff-47129d2fe9c1b2a8f38462f0c3cf42d9a11a39807dfbef165ffbfd0fe9ba6b14L386), the rest is just cleaning up a bit.

Fixes https://github.com/nextcloud/android/issues/9486