### PR TITLE
RemoteOperationResult: ignore location header if there are authentication headers present

### DIFF
--- a/src/main/java/com/owncloud/android/lib/common/operations/RemoteOperationResult.java
+++ b/src/main/java/com/owncloud/android/lib/common/operations/RemoteOperationResult.java
@@ -378,10 +378,10 @@ public class RemoteOperationResult<T extends Object> implements Serializable {
             Header current;
             for (Header httpHeader : httpHeaders) {
                 current = httpHeader;
-                if (HEADER_LOCATION.equals(current.getName().toLowerCase(Locale.US))) {
-                    mRedirectedLocation = current.getValue();
-                } else if (HEADER_WWW_AUTHENTICATE.equals(current.getName().toLowerCase(Locale.US))) {
+                if (HEADER_WWW_AUTHENTICATE.equals(current.getName().toLowerCase(Locale.US))) {
                     mAuthenticateHeaders.add(current.getValue());
+                } else if (HEADER_LOCATION.equals(current.getName().toLowerCase(Locale.US)) && mAuthenticateHeaders.isEmpty()) {
+                    mRedirectedLocation = current.getValue();
                 }
             }
         }

--- a/src/test/java/com/owncloud/android/lib/common/operations/RemoteOperationResultTest.kt
+++ b/src/test/java/com/owncloud/android/lib/common/operations/RemoteOperationResultTest.kt
@@ -72,7 +72,7 @@ class RemoteOperationResultTest {
         )
         Assert.assertEquals(
             "Wrong location header",
-            LOCATION_HEADER.value,
+            null,
             sut.redirectedLocation
         )
     }


### PR DESCRIPTION
In https://github.com/nextcloud/android-library/commit/d1ace843b510a0788794cd40ce75a13d6dec82d1, a change was introduced so that duplicate www-authenticate headers weren't ignored.

At the same time, this change unknowingly removed the previous behaviour of ignoring a location header if www_authenticate headers were present (and came first in the list). This resulted in servers returning both location headers and authenticate headers causing a loop in the login process: https://github.com/nextcloud/android/issues/9827

This commit fixes that, while also allowing multiple authentication headers as before.

As a side note, the connection check logic (including this part) is very opaque and should be reworked. `RemoteOperationResult` constructors also show inconsistent behaviour.

Fixes https://github.com/nextcloud/android/issues/9827