### PR TITLE
IPv4FallbackInterceptor: handle IllegalStateException when chain is exhausted

### DIFF
--- a/src/main/java/com/nextcloud/common/IPv4FallbackInterceptor.kt
+++ b/src/main/java/com/nextcloud/common/IPv4FallbackInterceptor.kt
@@ -71,6 +71,11 @@ class IPv4FallbackInterceptor(private val connectionPool: ConnectionPool) : Inte
         Log_OC.d(TAG, "Error with IPv6, trying IPv4")
         DNSCache.setIPVersionPreference(hostname, true)
         connectionPool.evictAll()
-        return chain.proceed(request)
+        return try {
+            chain.proceed(request)
+        } catch (e: IllegalStateException) {
+            Log_OC.w(TAG, e.stackTraceToString())
+            chain.call().clone().execute()
+        }
     }
 }


### PR DESCRIPTION
From play console error:

```
java.lang.IllegalStateException: 
  at okhttp3.internal.http.RealInterceptorChain.proceed (RealInterceptorChain.kt:99)
  at com.nextcloud.common.IPv4FallbackInterceptor.retryWithIPv4 (IPv4FallbackInterceptor.kt:74)
  at com.nextcloud.common.IPv4FallbackInterceptor.intercept (IPv4FallbackInterceptor.kt:54)
  at okhttp3.internal.http.RealInterceptorChain.proceed (RealInterceptorChain.kt:109)
```

This is likely caused by https://github.com/square/okhttp/blob/master/okhttp/src/jvmMain/kotlin/okhttp3/internal/http/RealInterceptorChain.kt#L99 (chain can only proceed once)