### PR TITLE
Have userId tests also for NextcloudClient

### DIFF
--- a/src/androidTest/java/com/owncloud/android/lib/common/OwnCloudClientTest.kt
+++ b/src/androidTest/java/com/owncloud/android/lib/common/OwnCloudClientTest.kt
@@ -27,8 +27,10 @@
 package com.owncloud.android.lib.common
 
 import android.net.Uri
+import com.nextcloud.common.NextcloudClient
 import com.owncloud.android.AbstractIT
 import junit.framework.Assert.assertEquals
+import okhttp3.Credentials.basic
 import org.junit.Test
 
 class OwnCloudClientTest : AbstractIT() {
@@ -61,16 +63,29 @@ class OwnCloudClientTest : AbstractIT() {
             false
         )
 
-        client.userId = "test"
-        assertEquals("Wrong encoded userId", "test", client.userId)
+        val credentials = basic("user", "password")
+        val nextcloudClient = NextcloudClient(url, "user", credentials, context)
 
-        client.userId = "test+test@test.localhost"
-        assertEquals("Wrong encoded userId", "test+test@test.localhost", client.userId)
+        val testList = ArrayList<Pair<String, String>>()
+        testList.add(Pair("test@test.de", "test@test.de"))
+        testList.add(Pair("Test User", "Test%20User"))
+        testList.add(Pair("test", "test"))
+        testList.add(Pair("test+test@test.localhost", "test+test@test.localhost"))
+        testList.add(Pair("test - ab4c", "test%20-%20ab4c"))
+        testList.add(Pair("test.-&51_+-?@test.localhost", "test.-%2651_+-%3F@test.localhost"))
 
-        client.userId = "test - ab4c"
-        assertEquals("Wrong encoded userId", "test%20-%20ab4c", client.userId)
+        testList.forEach { pair ->
+            client.userId = pair.first
+            assertEquals("Wrong encoded userId with ownCloudClient", pair.second, client.userId)
+            assertEquals(pair.first, client.userIdPlain)
 
-        client.userId = "test.-&51_+-?@test.localhost"
-        assertEquals("Wrong encoded userId", "test.-%2651_+-%3F@test.localhost", client.userId)
+            nextcloudClient.userId = pair.first
+            assertEquals(
+                "Wrong encoded userId with nextcloudClient",
+                pair.second,
+                nextcloudClient.getUserIdEncoded()
+            )
+            assertEquals(pair.first, nextcloudClient.getUserIdPlain())
+        }
     }
 }

--- a/src/main/java/com/nextcloud/common/NextcloudClient.kt
+++ b/src/main/java/com/nextcloud/common/NextcloudClient.kt
@@ -169,4 +169,12 @@ class NextcloudClient(
         }
         return result
     }
+
+    fun getUserIdEncoded(): String {
+        return Uri.encode(userId, OwnCloudClient.ALLOWED_USERID_CHARACTERS)
+    }
+
+    fun getUserIdPlain(): String {
+        return userId
+    }
 }

--- a/src/main/java/com/owncloud/android/lib/common/OwnCloudClient.java
+++ b/src/main/java/com/owncloud/android/lib/common/OwnCloudClient.java
@@ -66,7 +66,7 @@ public class OwnCloudClient extends HttpClient {
     /**
      * Characters to skip during userID encoding
      */
-    private static final String ALLOWED_USERID_CHARACTERS = "@+";
+    public static final String ALLOWED_USERID_CHARACTERS = "@+";
 
 
     private static byte[] sExhaustBuffer = new byte[1024];


### PR DESCRIPTION
I am unsure, if this is the best approach on NextcloudClient.
At least we have then a fitting method name, but on the other hand devs could still use nextcloudClient.userId which is then like plainId, but not known to them.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>