### PR TITLE
DNSCache: add TTL of 30 seconds to cache entries

### DIFF
--- a/library/.gitignore
+++ b/library/.gitignore
@@ -1,1 +1,4 @@
 /build
+
+# Test files
+/test

--- a/library/src/main/java/com/nextcloud/android/lib/core/Clock.kt
+++ b/library/src/main/java/com/nextcloud/android/lib/core/Clock.kt
@@ -1,0 +1,35 @@
+/*
+ *  Nextcloud Android Library is available under MIT license
+ *
+ *  @author Álvaro Brey Vilas
+ *  Copyright (C) 2022 Álvaro Brey Vilas
+ *  Copyright (C) 2022 Nextcloud GmbH
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ *  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ *  BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ *  ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+
+package com.nextcloud.android.lib.core
+
+interface Clock {
+    /**
+     * Current epoch time in millis
+     */
+    val currentTimeMillis: Long
+}

--- a/library/src/main/java/com/nextcloud/android/lib/core/ClockImpl.kt
+++ b/library/src/main/java/com/nextcloud/android/lib/core/ClockImpl.kt
@@ -1,0 +1,33 @@
+/*
+ *  Nextcloud Android Library is available under MIT license
+ *
+ *  @author Álvaro Brey Vilas
+ *  Copyright (C) 2022 Álvaro Brey Vilas
+ *  Copyright (C) 2022 Nextcloud GmbH
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ *  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ *  BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ *  ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+
+package com.nextcloud.android.lib.core
+
+class ClockImpl : Clock {
+    override val currentTimeMillis: Long
+        get() = System.currentTimeMillis()
+}

--- a/library/src/test/java/com/nextcloud/common/ClockStub.kt
+++ b/library/src/test/java/com/nextcloud/common/ClockStub.kt
@@ -1,0 +1,34 @@
+/*
+ * Nextcloud Android Library is available under MIT license
+ *
+ * @author Álvaro Brey Vilas
+ * Copyright (C) 2022 Álvaro Brey Vilas
+ * Copyright (C) 2022 Nextcloud GmbH
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.nextcloud.common
+
+import com.nextcloud.android.lib.core.Clock
+
+class ClockStub(private val currentTimeValue: Long) : Clock {
+    override val currentTimeMillis: Long
+        get() = currentTimeValue
+}


### PR DESCRIPTION
This will avoid cache living indefinitely through DNS changes if the app/network doesn't change.

30 seconds is the JVM default

Fixes https://github.com/nextcloud/android/issues/10018

Signed-off-by: Álvaro Brey Vilas <alvaro.brey@nextcloud.com>
