### PR TITLE
Update UploadFileRemoteOperation.java to get access to etag from resp…

### DIFF
--- a/library/src/main/java/com/owncloud/android/lib/resources/files/UploadFileRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/files/UploadFileRemoteOperation.java
@@ -35,6 +35,7 @@ import com.owncloud.android.lib.common.operations.RemoteOperation;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 
 import org.apache.commons.httpclient.DefaultHttpMethodRetryHandler;
+import org.apache.commons.httpclient.Header;
 import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.httpclient.methods.PutMethod;
 import org.apache.commons.httpclient.methods.RequestEntity;
@@ -56,6 +57,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class UploadFileRemoteOperation extends RemoteOperation {
 	private static final String OC_TOTAL_LENGTH_HEADER = "OC-Total-Length";
 	private static final String IF_MATCH_HEADER = "If-Match";
+	protected static final String RESULT_ETAG_HEADER = "etag";
 	protected static final String OC_X_OC_MTIME_HEADER = "X-OC-Mtime";
 	protected static final String OC_X_OC_CTIME_HEADER = "X-OC-Ctime";
 
@@ -231,6 +233,11 @@ public class UploadFileRemoteOperation extends RemoteOperation {
 			status = client.executeMethod(putMethod);
 
 			result = new RemoteOperationResult(isSuccess(status), putMethod);
+
+			final Header resultEtagHeader = putMethod.getResponseHeader(RESULT_ETAG_HEADER);
+			if (resultEtagHeader != null) {
+				result.setResultData(resultEtagHeader.getValue());
+			}
 
 			client.exhaustResponse(putMethod.getResponseBodyAsStream());
 

--- a/library/src/main/java/com/owncloud/android/lib/resources/files/UploadFileRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/files/UploadFileRemoteOperation.java
@@ -54,7 +54,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * @author masensio
  */
 
-public class UploadFileRemoteOperation extends RemoteOperation {
+public class UploadFileRemoteOperation extends RemoteOperation<String> {
 	private static final String OC_TOTAL_LENGTH_HEADER = "OC-Total-Length";
 	private static final String IF_MATCH_HEADER = "If-Match";
 	protected static final String RESULT_ETAG_HEADER = "etag";
@@ -157,8 +157,8 @@ public class UploadFileRemoteOperation extends RemoteOperation {
 	}
 
 	@Override
-	protected RemoteOperationResult run(OwnCloudClient client) {
-		RemoteOperationResult result;
+	protected RemoteOperationResult<String> run(OwnCloudClient client) {
+		RemoteOperationResult<String> result;
 		DefaultHttpMethodRetryHandler oldRetryHandler =
 			(DefaultHttpMethodRetryHandler) client.getParams().getParameter(HttpMethodParams.RETRY_HANDLER);
 
@@ -177,7 +177,7 @@ public class UploadFileRemoteOperation extends RemoteOperation {
 
 			if (cancellationRequested.get()) {
 				// the operation was cancelled before getting it's turn to be executed in the queue of uploads
-				result = new RemoteOperationResult(new OperationCancelledException());
+				result = new RemoteOperationResult<>(new OperationCancelledException());
 
 			} else {
 				// perform the upload
@@ -187,12 +187,12 @@ public class UploadFileRemoteOperation extends RemoteOperation {
 		} catch (Exception e) {
 			if (putMethod != null && putMethod.isAborted()) {
                 if (cancellationRequested.get() && cancellationReason != null) {
-                    result = new RemoteOperationResult(cancellationReason);
+                    result = new RemoteOperationResult<>(cancellationReason);
                 } else {
-                    result = new RemoteOperationResult(new OperationCancelledException());
+                    result = new RemoteOperationResult<>(new OperationCancelledException());
                 }
 			} else {
-				result = new RemoteOperationResult(e);
+				result = new RemoteOperationResult<>(e);
 			}
 		} finally {
 			if (disableRetries) {
@@ -208,9 +208,9 @@ public class UploadFileRemoteOperation extends RemoteOperation {
                 status == HttpStatus.SC_NO_CONTENT));
 	}
 
-	protected RemoteOperationResult uploadFile(OwnCloudClient client) throws IOException {
+	protected RemoteOperationResult<String> uploadFile(OwnCloudClient client) throws IOException {
 		int status;
-		RemoteOperationResult result;
+		RemoteOperationResult<String> result;
 
 		try {
 			File f = new File(localPath);
@@ -232,7 +232,7 @@ public class UploadFileRemoteOperation extends RemoteOperation {
 			putMethod.setRequestEntity(entity);
 			status = client.executeMethod(putMethod);
 
-			result = new RemoteOperationResult(isSuccess(status), putMethod);
+			result = new RemoteOperationResult<>(isSuccess(status), putMethod);
 
 			final Header resultEtagHeader = putMethod.getResponseHeader(RESULT_ETAG_HEADER);
 			if (resultEtagHeader != null) {


### PR DESCRIPTION
…onse header

- Add a private static final value which is the response header's name for etag.
- update 'RemoteOperationResult uploadFile(OwnCloudClient client)' to check for this header, and set value as RemoteOperationResult's data.