### PR TITLE
Add test for https://github.com/nextcloud/android-library/pull/870

### DIFF
--- a/library/src/androidTest/java/com/owncloud/android/lib/resources/files/UploadFileRemoteOperationIT.kt
+++ b/library/src/androidTest/java/com/owncloud/android/lib/resources/files/UploadFileRemoteOperationIT.kt
@@ -74,6 +74,7 @@ class UploadFileRemoteOperationIT : AbstractIT() {
 
         assertEquals(remotePath, remoteFile.remotePath)
         assertEquals(creationTimestamp, remoteFile.creationTimestamp)
+        assertEquals(uploadResult.resultData, remoteFile.etag)
         assertTrue(
             uploadTimestamp - TIME_OFFSET < remoteFile.uploadTimestamp ||
                 uploadTimestamp + TIME_OFFSET > remoteFile.uploadTimestamp

--- a/library/src/main/java/com/owncloud/android/lib/resources/files/UploadFileRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/files/UploadFileRemoteOperation.java
@@ -236,7 +236,7 @@ public class UploadFileRemoteOperation extends RemoteOperation<String> {
 
 			final Header resultEtagHeader = putMethod.getResponseHeader(RESULT_ETAG_HEADER);
 			if (resultEtagHeader != null) {
-				result.setResultData(resultEtagHeader.getValue());
+				result.setResultData(resultEtagHeader.getValue().replace("\"", ""));
 			}
 
 			client.exhaustResponse(putMethod.getResponseBodyAsStream());


### PR DESCRIPTION
I added a test for above PR.
While doing this, I noticed that response of UploadFileRemoteOperation is "etag", but in RemoteFile we use etag (without " ").
I think this should be consistent across lib and therefore removed "" in UFRO.

What do you think? @AlvaroBrey @vince-bourgmayer

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>