### PR TITLE
Add User interface and transitional API for RemoteOperation

### DIFF
--- a/library/src/main/java/com/nextcloud/common/User.java
+++ b/library/src/main/java/com/nextcloud/common/User.java
@@ -1,0 +1,9 @@
+package com.nextcloud.common;
+
+import android.accounts.Account;
+
+public interface User {
+    @Deprecated
+    Account toPlatformAccount();
+    String getAccountName();
+}

--- a/library/src/main/java/com/owncloud/android/lib/common/operations/RemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/common/operations/RemoteOperation.java
@@ -34,6 +34,7 @@ import android.os.Handler;
 import androidx.annotation.NonNull;
 
 import com.nextcloud.common.NextcloudClient;
+import com.nextcloud.common.User;
 import com.owncloud.android.lib.common.OwnCloudAccount;
 import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.common.OwnCloudClientFactory;
@@ -44,7 +45,6 @@ import com.owncloud.android.lib.common.operations.RemoteOperationResult.ResultCo
 import com.owncloud.android.lib.common.utils.Log_OC;
 
 import java.io.IOException;
-
 
 /**
  * Operation which execution involves one or several interactions with an ownCloud server.
@@ -144,6 +144,15 @@ public abstract class RemoteOperation<T> implements Runnable {
     }
 
     /**
+     * This is a transitional wrapper around {@link #execute(Account, Context)}
+     * using modern {@link User} interface instead of platform {@link Account}
+     */
+    @Deprecated
+    public RemoteOperationResult<T> execute(User user, Context context) {
+        return execute(user.toPlatformAccount(), context);
+    }
+
+    /**
      * Synchronously executes the remote operation on the received ownCloud account.
      * <p>
      * Do not call this method from the main thread.
@@ -167,6 +176,14 @@ public abstract class RemoteOperation<T> implements Runnable {
             return new RemoteOperationResult<T>(e);
         }
         return run(clientNew);
+    }
+
+    /**
+     * This is a transitional wrapper around {@link #executeNextcloudClient(Account, Context)} 
+     * using modern {@link User} interface instead of platform {@link Account}
+     */
+    public RemoteOperationResult<T> executeNextcloudClient(@NonNull User user, @NonNull Context context) {
+        return executeNextcloudClient(user.toPlatformAccount(), context);
     }
 
     /**
@@ -242,6 +259,15 @@ public abstract class RemoteOperation<T> implements Runnable {
         return runnerThread;
     }
 
+    /**
+     * This is a transitional wrapper around {@link #execute(Account, Context, OnRemoteOperationListener, Handler, Activity)}
+     * using modern {@link User} interface instead of platform {@link Account}
+     */
+    @Deprecated
+    public Thread execute(User user, Context context, OnRemoteOperationListener listener,
+                          Handler listenerHandler, Activity callerActivity) {
+	    return execute(user.toPlatformAccount(), context, listener, listenerHandler, callerActivity);
+    }
     
     /**
      * Asynchronously executes the remote operation
@@ -281,6 +307,15 @@ public abstract class RemoteOperation<T> implements Runnable {
         return runnerThread;
     }
 
+    /**
+     * This is a transitional wrapper around
+     * {@link #execute(Account, Context, OnRemoteOperationListener, Handler)}
+     * using modern {@link User} interface instead of platform {@link Account}
+     */
+    public Thread execute(User user, Context context,
+                          OnRemoteOperationListener listener, Handler listenerHandler) {
+        return execute(user.toPlatformAccount(), context, listener, listenerHandler);
+    }
     
 	/**
 	 * Asynchronously executes the remote operation


### PR DESCRIPTION
Android client is being migrated to new User model replacing
platform-specific Account and most of the use cases has been
migrated.

Majority of remaining uses are around RemoteOperation<T> subclasses.

This PR provides minimal User interface and wrappers around
RemoteOperation<T>.execute() methods allowing use of User model.

User interface provides minimal API to support the library cases and
shall be inherited by the client User interface in the client app.

Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>