### PR TITLE
build: More repo cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,8 @@
 subprojects {
     buildscript {
         repositories {
+            gradlePluginPortal()
             google()
-            maven {
-                url 'https://plugins.gradle.org/m2/'
-            }
             mavenCentral()
         }
     }
@@ -12,7 +10,6 @@ subprojects {
         google()
         mavenCentral()
         maven { url "https://jitpack.io" }
-        maven { url "https://maven.pkg.jetbrains.space/public/p/kotlinx-html/maven" }
     }
 }
 


### PR DESCRIPTION
- Use gradlePluginPortal() instead of explicit maven URL
- Remove jetbrains maven repo, it's unused


Follow up to #877