### PR TITLE
OCCapability: restore nullability of optional strings

### DIFF
--- a/library/src/main/java/com/owncloud/android/lib/resources/status/OCCapability.kt
+++ b/library/src/main/java/com/owncloud/android/lib/resources/status/OCCapability.kt
@@ -39,15 +39,15 @@ class OCCapability {
     var versionEdition: String? = null
 
     // Theming
-    var serverName = ""
-    var serverSlogan = ""
-    var serverColor = ""
-    var serverTextColor = ""
-    var serverElementColor = ""
-    var serverElementColorBright = ""
-    var serverElementColorDark = ""
-    var serverLogo = ""
-    var serverBackground = ""
+    var serverName: String? = ""
+    var serverSlogan: String? = ""
+    var serverColor: String? = ""
+    var serverTextColor: String? = ""
+    var serverElementColor: String? = ""
+    var serverElementColorBright: String? = ""
+    var serverElementColorDark: String? = ""
+    var serverLogo: String? = ""
+    var serverBackground: String? = ""
     var serverBackgroundDefault = CapabilityBooleanType.UNKNOWN
     var serverBackgroundPlain = CapabilityBooleanType.UNKNOWN
 
@@ -100,7 +100,7 @@ class OCCapability {
     var extendedSupport = CapabilityBooleanType.UNKNOWN
 
     // DirectEditing
-    var directEditingEtag: String = ""
+    var directEditingEtag: String? = ""
 
     // user status
     var userStatus = CapabilityBooleanType.UNKNOWN

--- a/library/src/test/java/com/owncloud/android/lib/resources/status/OCCapabilityTest.kt
+++ b/library/src/test/java/com/owncloud/android/lib/resources/status/OCCapabilityTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Nextcloud Android Library is available under MIT license
+ *
+ * @author Álvaro Brey Vilas
+ * Copyright (C) 2022 Álvaro Brey Vilas
+ * Copyright (C) 2022 Nextcloud GmbH
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.owncloud.android.lib.resources.status
+
+import org.junit.Test
+
+class OCCapabilityTest {
+
+    /**
+     * This won't compile if the fields below are not nullable. This is sort of redundant,
+     * but it's meant to prevent a crash in client apps when trying to assign null from Java.
+     */
+    @Test
+    fun testFieldNullability() {
+        OCCapability().apply {
+            serverName = null
+            serverSlogan = null
+            serverColor = null
+            serverTextColor = null
+            serverElementColor = null
+            serverElementColorBright = null
+            serverElementColorDark = null
+            serverLogo = null
+            serverBackground = null
+            directEditingEtag = null
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/nextcloud/android/issues/10162