### PR TITLE
Convert User interface to Kotlin

### DIFF
--- a/library/src/main/java/com/nextcloud/common/User.java
+++ b/library/src/main/java/com/nextcloud/common/User.java
@@ -1,9 +1,0 @@
-package com.nextcloud.common;
-
-import android.accounts.Account;
-
-public interface User {
-    @Deprecated
-    Account toPlatformAccount();
-    String getAccountName();
-}

--- a/library/src/main/java/com/nextcloud/common/User.kt
+++ b/library/src/main/java/com/nextcloud/common/User.kt
@@ -1,0 +1,10 @@
+package com.nextcloud.common
+
+import android.accounts.Account
+
+interface User {
+    val accountName: String
+
+    @Deprecated("Temporary workaround")
+    fun toPlatformAccount(): Account
+}


### PR DESCRIPTION
Inheriting java interface (lib) in Kotlin interface (app) does now work
due to method signature conflict. Base User interace must be in Kotlin.

Signed-off-by: Chris Narkiewicz <hello@ezaquarii.com>