### PR TITLE
OCCapability: more nullability fixes

### DIFF
--- a/library/src/main/java/com/owncloud/android/lib/resources/status/OCCapability.kt
+++ b/library/src/main/java/com/owncloud/android/lib/resources/status/OCCapability.kt
@@ -29,13 +29,13 @@ package com.owncloud.android.lib.resources.status
  */
 class OCCapability {
     var id: Long = 0
-    var accountName = ""
+    var accountName: String? = ""
 
     // Server version
     var versionMayor = 0
     var versionMinor = 0
     var versionMicro = 0
-    var versionString = ""
+    var versionString: String? = ""
     var versionEdition: String? = null
 
     // Theming
@@ -91,9 +91,9 @@ class OCCapability {
     var richDocuments = CapabilityBooleanType.UNKNOWN
     var richDocumentsDirectEditing = CapabilityBooleanType.FALSE
     var richDocumentsTemplatesAvailable = CapabilityBooleanType.FALSE
-    var richDocumentsMimeTypeList: List<String> = emptyList()
-    var richDocumentsOptionalMimeTypeList: List<String> = emptyList()
-    var richDocumentsProductName: String = "Collabora Online"
+    var richDocumentsMimeTypeList: List<String>? = emptyList()
+    var richDocumentsOptionalMimeTypeList: List<String>? = emptyList()
+    var richDocumentsProductName: String? = "Collabora Online"
 
     var activity = CapabilityBooleanType.UNKNOWN
 
@@ -107,7 +107,7 @@ class OCCapability {
     var userStatusSupportsEmoji = CapabilityBooleanType.UNKNOWN
 
     // Etag for capabilities
-    var etag: String = ""
+    var etag: String? = ""
 
     val version: OwnCloudVersion
         get() = OwnCloudVersion(listOf(versionMayor, versionMinor, versionMicro).joinToString(VERSION_DOT))

--- a/library/src/test/java/com/owncloud/android/lib/resources/status/OCCapabilityTest.kt
+++ b/library/src/test/java/com/owncloud/android/lib/resources/status/OCCapabilityTest.kt
@@ -38,6 +38,9 @@ class OCCapabilityTest {
     @Test
     fun testFieldNullability() {
         OCCapability().apply {
+            accountName = null
+            versionString = null
+            versionEdition = null
             serverName = null
             serverSlogan = null
             serverColor = null
@@ -47,6 +50,9 @@ class OCCapabilityTest {
             serverElementColorDark = null
             serverLogo = null
             serverBackground = null
+            richDocumentsMimeTypeList = null
+            richDocumentsOptionalMimeTypeList = null
+            richDocumentsProductName = null
             directEditingEtag = null
         }
     }


### PR DESCRIPTION
There's _still_ more fields that can be assigned null from the client logic.

I've made nullable everything except fields that were primitive (long, int) before the Kotlin conversion,
and CapabilityBooleanTypes (as fromValue there returns UNKNOWN for null, doesn't crash).

Hopefully that's the last of them

Fixes https://github.com/nextcloud/android/issues/10197

Signed-off-by: Álvaro Brey <alvaro.brey@nextcloud.com>
