### PR TITLE
Revert "Bump gradle from 7.1.3 to 7.2.1"

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue May 10 08:13:43 CEST 2022
+#Wed Jan 26 10:28:13 CET 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         lombokVersion = "1.18.24"
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.1'
+        classpath 'com.android.tools.build:gradle:7.1.3'
         classpath 'com.hiya:jacoco-android:0.2'
         classpath 'com.github.spotbugs.snom:spotbugs-gradle-plugin:5.0.9'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"

--- a/library/src/main/java/com/nextcloud/common/OkHttpMethodBase.kt
+++ b/library/src/main/java/com/nextcloud/common/OkHttpMethodBase.kt
@@ -55,7 +55,7 @@ abstract class OkHttpMethodBase(
     private val requestBuilder: Request.Builder = Request.Builder()
     private var request: Request? = null
 
-    init {
+    fun OkHttpMethodBase() {
         requestHeaders["http.protocol.single-cookie-header"] = "true"
     }
 


### PR DESCRIPTION
Reverts nextcloud/android-library#893

Reverted due to incompatibility with the app repo, which can't be updated yet due to an AGP 7.2.x bug with JaCoCo