### PR TITLE
Revert "Bump kotlin_version from 1.6.21 to 1.7.0"

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,7 +2,7 @@ import com.github.spotbugs.snom.SpotBugsTask
 
 buildscript {
     ext {
-        kotlin_version = '1.7.0'
+        kotlin_version = '1.6.21'
         junit_version = '4.13.2'
         jacoco_version = '0.8.8'
         lombokVersion = "1.18.24"

--- a/library/src/main/java/com/nextcloud/common/OkHttpMethodBase.kt
+++ b/library/src/main/java/com/nextcloud/common/OkHttpMethodBase.kt
@@ -60,12 +60,9 @@ abstract class OkHttpMethodBase(
     }
 
     fun buildQueryParameter(): HttpUrl {
-        val httpBuilder =
-            uri.toHttpUrlOrNull()?.newBuilder() ?: throw IllegalStateException("Error")
+        val httpBuilder = uri.toHttpUrlOrNull()?.newBuilder() ?: throw IllegalStateException("Error")
 
-        for ((k, v) in queryMap) {
-            httpBuilder.addQueryParameter(k, v)
-        }
+        queryMap.forEach { (k, v) -> httpBuilder.addQueryParameter(k, v) }
 
         return httpBuilder.build()
     }
@@ -137,9 +134,7 @@ abstract class OkHttpMethodBase(
 
         requestHeaders[AUTHORIZATION] = nextcloudClient.credentials
         requestHeaders[USER_AGENT] = OwnCloudClientManagerFactory.getUserAgent()
-        for ((name, value) in requestHeaders) {
-            temp.header(name, value)
-        }
+        requestHeaders.forEach { (name, value) -> temp.header(name, value) }
 
         if (useOcsApiRequestHeader) {
             temp.header(RemoteOperation.OCS_API_HEADER, RemoteOperation.OCS_API_HEADER_VALUE)
@@ -166,9 +161,7 @@ abstract class OkHttpMethodBase(
         val temp = requestBuilder.url(buildQueryParameter())
 
         requestHeaders[USER_AGENT] = OwnCloudClientManagerFactory.getUserAgent()
-        for ((name, value) in requestHeaders) {
-            temp.header(name, value)
-        }
+        requestHeaders.forEach { (name, value) -> temp.header(name, value) }
 
         applyType(temp)
 


### PR DESCRIPTION
Reverts nextcloud/android-library#906

Breaks lint in Files app because Files app can't be updated to AGP 7.2.x yet