### PR TITLE
Remove byte-buddy dependency

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -82,7 +82,6 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.4.0'
     androidTestImplementation 'commons-io:commons-io:2.11.0'
-    androidTestImplementation 'net.bytebuddy:byte-buddy:1.12.13'
 }
 
 spotbugs {

--- a/library/src/androidTest/java/com/nextcloud/test/RandomStringGenerator.kt
+++ b/library/src/androidTest/java/com/nextcloud/test/RandomStringGenerator.kt
@@ -1,0 +1,41 @@
+/* Nextcloud Android Library is available under MIT license
+ *
+ *   @author Álvaro Brey
+ *   Copyright (C) 2022 Álvaro Brey
+ *   Copyright (C) 2022 Nextcloud GmbH
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining a copy
+ *   of this software and associated documentation files (the "Software"), to deal
+ *   in the Software without restriction, including without limitation the rights
+ *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *   copies of the Software, and to permit persons to whom the Software is
+ *   furnished to do so, subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ *   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ *   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ *   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ *   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *   THE SOFTWARE.
+ *
+ */
+
+package com.nextcloud.test
+
+object RandomStringGenerator {
+    private const val DEFAULT_LENGTH = 8
+    private val ALLOWED_CHARACTERS = ('A'..'Z') + ('a'..'z') + ('0'..'9')
+
+    @JvmOverloads
+    @JvmStatic
+    fun make(length: Int = DEFAULT_LENGTH): String {
+        return (1..length)
+            .map { ALLOWED_CHARACTERS.random() }
+            .joinToString("")
+    }
+}

--- a/library/src/androidTest/java/com/owncloud/android/lib/resources/e2ee/UpdateMetadataRemoteOperationIT.java
+++ b/library/src/androidTest/java/com/owncloud/android/lib/resources/e2ee/UpdateMetadataRemoteOperationIT.java
@@ -30,6 +30,7 @@ import static org.junit.Assume.assumeTrue;
 
 import android.text.TextUtils;
 
+import com.nextcloud.test.RandomStringGenerator;
 import com.owncloud.android.AbstractIT;
 import com.owncloud.android.lib.common.OwnCloudClientManagerFactory;
 import com.owncloud.android.lib.resources.files.CreateFolderRemoteOperation;
@@ -38,8 +39,6 @@ import com.owncloud.android.lib.resources.files.model.RemoteFile;
 import com.owncloud.android.lib.resources.status.GetCapabilitiesRemoteOperation;
 import com.owncloud.android.lib.resources.status.OCCapability;
 import com.owncloud.android.lib.resources.status.OwnCloudVersion;
-
-import net.bytebuddy.utility.RandomString;
 
 import org.junit.Test;
 
@@ -58,7 +57,7 @@ public class UpdateMetadataRemoteOperationIT extends AbstractIT {
         OwnCloudClientManagerFactory.setUserAgent("Mozilla/5.0 (Android) Nextcloud-android/3.13.0");
 
         // create folder
-        String folder = "/" + RandomString.make(20) + "/";
+        String folder = "/" + RandomStringGenerator.make(20) + "/";
         assertTrue(new CreateFolderRemoteOperation(folder, true).execute(client).isSuccess());
         RemoteFile remoteFolder = (RemoteFile) new ReadFileRemoteOperation(folder).execute(client).getSingleData();
 


### PR DESCRIPTION
Only used to generate random strings in tests, creates too many dependabot PRs

Based on https://github.com/nextcloud/android/pull/10441
