### PR TITLE
ChunkedFileRemoteOperation: correctly use lastModificationTimestamp

### DIFF
--- a/library/src/main/java/com/owncloud/android/lib/resources/files/ChunkedFileUploadRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/files/ChunkedFileUploadRemoteOperation.java
@@ -207,7 +207,7 @@ public class ChunkedFileUploadRemoteOperation extends UploadFileRemoteOperation 
             String originUri = uploadFolderUri + "/.file";
 
             moveMethod = new MoveMethod(originUri, destinationUri, true);
-            moveMethod.addRequestHeader(OC_X_OC_MTIME_HEADER, String.valueOf(file.lastModified() / 1000));
+            moveMethod.addRequestHeader(OC_X_OC_MTIME_HEADER, lastModificationTimestamp);
 
             if (creationTimestamp != null && creationTimestamp > 0) {
                 moveMethod.addRequestHeader(OC_X_OC_CTIME_HEADER, String.valueOf(creationTimestamp));

--- a/library/src/main/java/com/owncloud/android/lib/resources/files/UploadFileRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/files/UploadFileRemoteOperation.java
@@ -64,7 +64,7 @@ public class UploadFileRemoteOperation extends RemoteOperation<String> {
     protected String localPath;
     protected String remotePath;
     protected String mimeType;
-    private String lastModificationTimestamp;
+    protected String lastModificationTimestamp;
     protected Long creationTimestamp = null;
     protected boolean disableRetries = false;
     PutMethod putMethod = null;

--- a/library/src/main/java/com/owncloud/android/lib/resources/files/UploadFileRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/files/UploadFileRemoteOperation.java
@@ -64,6 +64,9 @@ public class UploadFileRemoteOperation extends RemoteOperation<String> {
     protected String localPath;
     protected String remotePath;
     protected String mimeType;
+    /**
+     * Must be in seconds, according to UNIX time
+     */
     protected String lastModificationTimestamp;
     protected Long creationTimestamp = null;
     protected boolean disableRetries = false;


### PR DESCRIPTION
Fixes https://github.com/nextcloud/android/issues/10900
