### PR TITLE
NextcloudUriDelegate: avoid double-slash in files dav paths

### DIFF
--- a/library/src/androidTest/java/com/nextcloud/common/NextcloudUriDelegateIT.kt
+++ b/library/src/androidTest/java/com/nextcloud/common/NextcloudUriDelegateIT.kt
@@ -1,0 +1,36 @@
+package com.nextcloud.common
+
+import android.net.Uri
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+class NextcloudUriDelegateIT {
+
+    lateinit var sut: NextcloudUriDelegate
+
+    @Before
+    fun setUp() {
+        sut = NextcloudUriDelegate(Uri.parse(BASEURL), USERID)
+    }
+
+    @Test
+    fun testFilesDavUri_leadingSlashInPath() {
+        val expected = "$EXPECTED_FILES_DAV/path/to/file.txt"
+        val actual = sut.getFilesDavUri("/path/to/file.txt")
+        Assert.assertEquals("Wrong URL", expected, actual)
+    }
+
+    @Test
+    fun testFilesDavUri_noLeadingSlashInPath() {
+        val expected = "$EXPECTED_FILES_DAV/path/to/file.txt"
+        val actual = sut.getFilesDavUri("path/to/file.txt")
+        Assert.assertEquals("Wrong URL", expected, actual)
+    }
+
+    companion object {
+        private const val USERID = "user"
+        private const val BASEURL = "http://test.localhost"
+        private const val EXPECTED_FILES_DAV = "$BASEURL/remote.php/dav/files/$USERID"
+    }
+}

--- a/library/src/main/java/com/nextcloud/common/NextcloudUriDelegate.kt
+++ b/library/src/main/java/com/nextcloud/common/NextcloudUriDelegate.kt
@@ -61,7 +61,8 @@ class NextcloudUriDelegate(baseUri: Uri, var userId: String?) : NextcloudUriProv
         get() = Uri.parse(baseUri.toString() + AccountUtils.WEBDAV_PATH_9_0)
 
     override fun getFilesDavUri(path: String): String {
-        return "$filesDavUri/${WebdavUtils.encodePath(path)}"
+        // encodePath already adds leading slash if needed
+        return "$filesDavUri${WebdavUtils.encodePath(path)}"
     }
 
     override fun getCommentsUri(fileId: String): String {


### PR DESCRIPTION
Fixes https://github.com/nextcloud/android/issues/10774
Fixes https://github.com/nextcloud/android-library/issues/994


