### PR TITLE
Support client certificates

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -48,6 +48,7 @@ configurations {
 }
 
 dependencies {
+    implementation 'com.github.stephanritscher:InteractiveKeyManager:0.1'
     implementation 'org.apache.jackrabbit:jackrabbit-webdav:2.13.5'
     api 'com.squareup.okhttp3:okhttp:5.0.0-alpha.10'
     implementation 'com.gitlab.bitfireAT:dav4jvm:2.1.3' // in transition phase, we use old and new libs

--- a/library/src/main/java/com/owncloud/android/lib/common/OwnCloudClient.java
+++ b/library/src/main/java/com/owncloud/android/lib/common/OwnCloudClient.java
@@ -25,6 +25,7 @@
 
 package com.owncloud.android.lib.common;
 
+import android.content.Context;
 import android.net.Uri;
 
 import com.nextcloud.common.DNSCache;
@@ -53,6 +54,10 @@ import java.net.ConnectException;
 import java.net.SocketTimeoutException;
 import java.util.Locale;
 
+import de.ritscher.ssl.InteractiveKeyManager;
+import lombok.Getter;
+import lombok.Setter;
+
 public class OwnCloudClient extends HttpClient {
 
     private static final String TAG = OwnCloudClient.class.getSimpleName();
@@ -69,10 +74,14 @@ public class OwnCloudClient extends HttpClient {
     private OwnCloudCredentials credentials = null;
     private int mInstanceNumber;
 
+    @Getter private Uri baseUri;
+    @Setter private String userId;
+    private Context context;
+
     /**
      * Constructor
      */
-    public OwnCloudClient(Uri baseUri, HttpConnectionManager connectionMgr) {
+    public OwnCloudClient(Uri baseUri, HttpConnectionManager connectionMgr, Context context) {
         super(connectionMgr);
 
         if (baseUri == null) {
@@ -80,6 +89,9 @@ public class OwnCloudClient extends HttpClient {
         }
         nextcloudUriDelegate = new NextcloudUriDelegate(baseUri);
 
+        this.baseUri = baseUri;
+        this.context = context;
+        
         mInstanceNumber = sInstanceCounter++;
         Log_OC.d(TAG + " #" + mInstanceNumber, "Creating OwnCloudClient");
 
@@ -206,6 +218,10 @@ public class OwnCloudClient extends HttpClient {
 //	        logCookiesAtState("after");
 //	        logSetCookiesAtResponse(method.getResponseHeaders());
 
+            if (status >= 400 && status < 500) {
+                Log_OC.w(TAG, "executeMethod failed with error code " + status + "; remove key chain aliases disabled");
+                //new InteractiveKeyManager(context).removeKeys(baseUri.getHost(), baseUri.getPort());
+            }
             return status;
 
         } catch (SocketTimeoutException | ConnectException e) {

--- a/library/src/main/java/com/owncloud/android/lib/common/OwnCloudClientFactory.java
+++ b/library/src/main/java/com/owncloud/android/lib/common/OwnCloudClientFactory.java
@@ -151,7 +151,8 @@ public class OwnCloudClientFactory {
             Log_OC.e(TAG, "The local server truststore could not be read. Default SSL management" +
                     " in the system will be used for HTTPS connections", e);
         }
-        OwnCloudClient client = new OwnCloudClient(uri, NetworkUtils.getMultiThreadedConnManager());
+
+        OwnCloudClient client = new OwnCloudClient(uri, NetworkUtils.getMultiThreadedConnManager(), context);
         client.setDefaultTimeouts(DEFAULT_DATA_TIMEOUT, DEFAULT_CONNECTION_TIMEOUT);
         client.setFollowRedirects(followRedirects);
 

--- a/sample_client/build.gradle
+++ b/sample_client/build.gradle
@@ -32,7 +32,7 @@ android {
         exclude 'META-INF/LICENSE.txt'
     }
     defaultConfig {
-        minSdkVersion 14
+        minSdkVersion 21
         targetSdkVersion 28
     }
 }


### PR DESCRIPTION
This change adds support for configurations where the webserver requests a client certificate, e.g. via nginx configuration options ssl_client_certificate and ssl_verify_client. The client certificate handling is done via InteractiveKeyManager which prompts for a client certificate from a file or the devices keystore.

This change is NOT about client certificate authentication to the nextcloud server instance. The regular authentication mechanisms will be used as soon as the communication on TLS level is established.

The change addresses ticket #603, while not being a generic solution IMO.