### PR TITLE
Build unit and androidTest code before committing

### DIFF
--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -12,3 +12,8 @@ if ! ./gradlew --daemon detekt &>/dev/null; then
     echo >&2 "Detekt failed! See report at file://$(pwd)/library/build/reports/detekt/detekt.html"
     exit 1
 fi
+
+if ! ./gradlew compileReleaseUnitTestSources compileDebugAndroidTestSources; then
+  echo >&2 "Compilation of unit test and androidTest code failed!"
+  exit 1
+fi


### PR DESCRIPTION
Sometimes it happens that a code change kills tests.
This prevents us time-intensive roundtrips via CI.

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>