### PR TITLE
Increase wait time for `wait_for_server`

### DIFF
--- a/scripts/wait_for_server.sh
+++ b/scripts/wait_for_server.sh
@@ -10,7 +10,7 @@ until [[ $status = "false" ]]; do
 
     if [[ "$status" =~ "false" || "$status" = "" ]]; then
         let "counter += 1"
-         if [[ $counter -gt 10 ]]; then
+         if [[ $counter -gt 50 ]]; then
             echo "Failed to wait for server"
             exit 1
         fi


### PR DESCRIPTION
This script waits for the server to wake up during CI before launching tests.
In this library it only waited for 100 seconds instead of the 500 seconds it waits in the Files app.

This caused "failed to wait for server" in some occasions where the server image needs to be downloaded
and there's slow internet or poor performance.