### PR TITLE
Switch to new dav4jvm repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,12 @@ subprojects {
     repositories {
         google()
         mavenCentral()
-        maven { url "https://jitpack.io" }
+        maven {
+            url "https://jitpack.io"
+            content {
+                includeGroup "com.github.bitfireAT"
+            }
+        }
     }
 }
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -50,7 +50,7 @@ configurations {
 dependencies {
     implementation 'org.apache.jackrabbit:jackrabbit-webdav:2.13.5'
     api 'com.squareup.okhttp3:okhttp:5.0.0-alpha.11'
-    implementation 'com.gitlab.bitfireAT:dav4jvm:2.1.3' // in transition phase, we use old and new libs
+    implementation 'com.github.bitfireAT:dav4jvm:2.1.3' // in transition phase, we use old and new libs
     implementation group: 'com.google.code.gson', name: 'gson', version: '2.10.1'
     implementation 'androidx.annotation:annotation:1.6.0'
     compileOnly 'com.google.code.findbugs:annotations:3.0.1u2'


### PR DESCRIPTION
Also limit jitpack lookups to `bitfireAT` group for improved build perf & [security](https://github.com/nextcloud/news-android/issues/1109).