### PR TITLE
Introduce drop-account capability

### DIFF
--- a/library/src/androidTest/java/com/owncloud/android/GetCapabilitiesIT.java
+++ b/library/src/androidTest/java/com/owncloud/android/GetCapabilitiesIT.java
@@ -130,6 +130,7 @@ public class GetCapabilitiesIT extends AbstractIT {
         assertFalse(capability.getEtag().isEmpty());
         assertSame(CapabilityBooleanType.FALSE, capability.getRichDocuments());
         assertFalse(capability.getDirectEditingEtag().isEmpty());
+        assertSame(CapabilityBooleanType.UNKNOWN, capability.getDropAccount());
 
         // user status
         if (capability.getVersion().isNewerOrEqual(OwnCloudVersion.nextcloud_20)) {

--- a/library/src/main/java/com/owncloud/android/lib/resources/status/GetCapabilitiesRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/status/GetCapabilitiesRemoteOperation.java
@@ -166,6 +166,9 @@ public class GetCapabilitiesRemoteOperation extends RemoteOperation {
     // end to end encryption
     private static final String PROPERTY_KEYS_EXIST = "keys-exist";
 
+    // drop-account
+    private static final String NODE_DROP_ACCOUNT = "drop-account";
+
 
     private OCCapability currentCapability = null;
 
@@ -672,6 +675,17 @@ public class GetCapabilitiesRemoteOperation extends RemoteOperation {
                     }
                 } else {
                     capability.setGroupfolders(CapabilityBooleanType.FALSE);
+                }
+
+                // drop-account
+                if (respCapabilities.has(NODE_DROP_ACCOUNT)) {
+                    JSONObject dropAccountCapability = respCapabilities.getJSONObject(NODE_DROP_ACCOUNT);
+
+                    if (dropAccountCapability.getBoolean(PROPERTY_ENABLED)) {
+                        capability.setDropAccount(CapabilityBooleanType.TRUE);
+                    } else {
+                        capability.setDropAccount(CapabilityBooleanType.FALSE);
+                    }
                 }
             }
 

--- a/library/src/main/java/com/owncloud/android/lib/resources/status/OCCapability.kt
+++ b/library/src/main/java/com/owncloud/android/lib/resources/status/OCCapability.kt
@@ -110,6 +110,9 @@ class OCCapability {
     // Groupfolders
     var groupfolders = CapabilityBooleanType.UNKNOWN
 
+    // Drop-Account
+    var dropAccount = CapabilityBooleanType.UNKNOWN
+
     // Etag for capabilities
     var etag: String? = ""
 


### PR DESCRIPTION
This change introduces the `drop-account` capability required by nextcloud/android#11950. The corresponding server-side plug-in change is documented [here](https://framagit.org/framasoft/nextcloud/drop_account/-/issues/25#note_2005909).