### PR TITLE
Deprecate OwncloudClient - Helpers

### DIFF
--- a/library/src/main/java/com/nextcloud/common/JSONRequestBody.kt
+++ b/library/src/main/java/com/nextcloud/common/JSONRequestBody.kt
@@ -1,3 +1,10 @@
+/*
+ * Nextcloud Android Library
+ *
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2024 ZetaTom <70907959+zetatom@users.noreply.github.com>
+ * SPDX-License-Identifier: MIT
+ */
 package com.nextcloud.common
 
 import com.google.gson.Gson

--- a/library/src/main/java/com/nextcloud/common/JSONRequestBody.kt
+++ b/library/src/main/java/com/nextcloud/common/JSONRequestBody.kt
@@ -1,0 +1,31 @@
+package com.nextcloud.common
+
+import com.google.gson.Gson
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
+
+class JSONRequestBody() {
+    private val content = mutableMapOf<String, String>()
+
+    constructor(key: String, value: String) : this() {
+        put(key, value)
+    }
+
+    fun put(key: String, value: String) {
+        content[key] = value
+    }
+
+    fun get(): RequestBody {
+        val json = Gson().toJson(content)
+        return json.toRequestBody(JSON_MEDIATYPE)
+    }
+
+    override fun toString(): String {
+        return content.toString()
+    }
+
+    companion object {
+        private val JSON_MEDIATYPE = "application/json; charset=utf-8".toMediaType()
+    }
+}

--- a/library/src/main/java/com/nextcloud/common/JSONRequestBody.kt
+++ b/library/src/main/java/com/nextcloud/common/JSONRequestBody.kt
@@ -12,7 +12,10 @@ class JSONRequestBody() {
         put(key, value)
     }
 
-    fun put(key: String, value: String) {
+    fun put(
+        key: String,
+        value: String
+    ) {
         content[key] = value
     }
 

--- a/library/src/main/java/com/nextcloud/operations/HeadMethod.kt
+++ b/library/src/main/java/com/nextcloud/operations/HeadMethod.kt
@@ -1,30 +1,10 @@
-/* Nextcloud Android Library is available under MIT license
+/*
+ * Nextcloud Android Library
  *
- *   @author ZetaTom
- *   Copyright (C) 2023 Tobias Kaminsky
- *   Copyright (C) 2023 Nextcloud GmbH
- *
- *   Permission is hereby granted, free of charge, to any person obtaining a copy
- *   of this software and associated documentation files (the "Software"), to deal
- *   in the Software without restriction, including without limitation the rights
- *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- *   copies of the Software, and to permit persons to whom the Software is
- *   furnished to do so, subject to the following conditions:
- *
- *   The above copyright notice and this permission notice shall be included in
- *   all copies or substantial portions of the Software.
- *
- *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- *   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- *   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- *   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
- *   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
- *   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
- *   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- *   THE SOFTWARE.
- *
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2024 ZetaTom <70907959+zetatom@users.noreply.github.com>
+ * SPDX-License-Identifier: MIT
  */
-
 package com.nextcloud.operations
 
 import com.nextcloud.common.OkHttpMethodBase

--- a/library/src/main/java/com/nextcloud/operations/HeadMethod.kt
+++ b/library/src/main/java/com/nextcloud/operations/HeadMethod.kt
@@ -1,0 +1,43 @@
+/* Nextcloud Android Library is available under MIT license
+ *
+ *   @author ZetaTom
+ *   Copyright (C) 2023 Tobias Kaminsky
+ *   Copyright (C) 2023 Nextcloud GmbH
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining a copy
+ *   of this software and associated documentation files (the "Software"), to deal
+ *   in the Software without restriction, including without limitation the rights
+ *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *   copies of the Software, and to permit persons to whom the Software is
+ *   furnished to do so, subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ *   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ *   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ *   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ *   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *   THE SOFTWARE.
+ *
+ */
+
+package com.nextcloud.operations
+
+import com.nextcloud.common.OkHttpMethodBase
+import okhttp3.Request
+
+/**
+ * HTTP HEAD method that uses OkHttp with new NextcloudClient
+ */
+class HeadMethod(
+    uri: String,
+    useOcsApiRequestHeader: Boolean
+) : OkHttpMethodBase(uri, useOcsApiRequestHeader) {
+    override fun applyType(temp: Request.Builder) {
+        temp.head()
+    }
+}


### PR DESCRIPTION
This is one of a series of pull requests which aim to replace all instances of `OwnCloudClient` with `NextcloudClient`. The reason for this change is that the newer `NextcloudClient` uses OkHttp, replacing the outdated Jackrabbit methods.

Specifically, this pull request implements the following:
- helper classes to ease the transition and refactoring
- general changes