### PR TITLE
Deprecate OwncloudClient - DirectEditing

### DIFF
--- a/library/src/androidTest/java/com/nextcloud/android/lib/resources/directediting/DirectEditingCreateFileRemoteOperationIT.java
+++ b/library/src/androidTest/java/com/nextcloud/android/lib/resources/directediting/DirectEditingCreateFileRemoteOperationIT.java
@@ -7,13 +7,13 @@
  */
 package com.nextcloud.android.lib.resources.directediting;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import com.owncloud.android.AbstractIT;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 
 import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class DirectEditingCreateFileRemoteOperationIT extends AbstractIT {
     @Test
@@ -21,7 +21,7 @@ public class DirectEditingCreateFileRemoteOperationIT extends AbstractIT {
         RemoteOperationResult<String> result = new DirectEditingCreateFileRemoteOperation("/test.md",
                 "text",
                 "textdocument")
-                .execute(client);
+                .execute(nextcloudClient);
         assertTrue(result.isSuccess());
 
         String url = result.getResultData();
@@ -35,7 +35,7 @@ public class DirectEditingCreateFileRemoteOperationIT extends AbstractIT {
                                                                                           "text",
                                                                                           "textdocument",
                                                                                           "1")
-                .execute(client);
+                .execute(nextcloudClient);
         assertTrue(result.isSuccess());
 
         String url = result.getResultData();
@@ -49,7 +49,7 @@ public class DirectEditingCreateFileRemoteOperationIT extends AbstractIT {
                                                                                           "text",
                                                                                           "textdocument",
                                                                                           "1")
-                .execute(client);
+                .execute(nextcloudClient);
         assertTrue(result.isSuccess());
 
         String url = result.getResultData();

--- a/library/src/androidTest/java/com/nextcloud/android/lib/resources/directediting/DirectEditingObtainListOfTemplatesRemoteOperationIT.java
+++ b/library/src/androidTest/java/com/nextcloud/android/lib/resources/directediting/DirectEditingObtainListOfTemplatesRemoteOperationIT.java
@@ -7,27 +7,29 @@
  */
 package com.nextcloud.android.lib.resources.directediting;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import com.owncloud.android.AbstractIT;
 import com.owncloud.android.lib.common.TemplateList;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 
 import org.junit.Test;
 
+import java.util.Objects;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 public class DirectEditingObtainListOfTemplatesRemoteOperationIT extends AbstractIT {
 
     @Test
     public void testGetAll() {
-        RemoteOperationResult result = new DirectEditingObtainListOfTemplatesRemoteOperation("text",
+        RemoteOperationResult<TemplateList> result = new DirectEditingObtainListOfTemplatesRemoteOperation("text",
                 "textdocument")
-                .execute(client);
+                .execute(nextcloudClient);
         assertTrue(result.isSuccess());
 
         TemplateList templateList = (TemplateList) result.getResultData();
 
-        assertEquals("Empty file", templateList.getTemplates().get("empty").getTitle());
-        assertEquals("md", templateList.getTemplates().get("empty").getExtension());
+        assertEquals("Empty file", Objects.requireNonNull(templateList.getTemplates().get("empty")).getTitle());
+        assertEquals("md", Objects.requireNonNull(templateList.getTemplates().get("empty")).getExtension());
     }
 }

--- a/library/src/androidTest/java/com/nextcloud/android/lib/resources/directediting/DirectEditingObtainRemoteOperationIT.kt
+++ b/library/src/androidTest/java/com/nextcloud/android/lib/resources/directediting/DirectEditingObtainRemoteOperationIT.kt
@@ -17,7 +17,7 @@ import org.junit.Test
 class DirectEditingObtainRemoteOperationIT : AbstractIT() {
     @Test
     fun testGetAll() {
-        val result = DirectEditingObtainRemoteOperation().execute(client)
+        val result = DirectEditingObtainRemoteOperation().run(nextcloudClient)
         assertTrue(result.isSuccess)
 
         val (editors, creators) = result.resultData

--- a/library/src/androidTest/java/com/nextcloud/android/lib/resources/directediting/DirectEditingOpenFileRemoteOperationIT.java
+++ b/library/src/androidTest/java/com/nextcloud/android/lib/resources/directediting/DirectEditingOpenFileRemoteOperationIT.java
@@ -7,9 +7,6 @@
  */
 package com.nextcloud.android.lib.resources.directediting;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import com.owncloud.android.AbstractIT;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.lib.resources.files.ReadFileRemoteOperation;
@@ -20,6 +17,9 @@ import junit.framework.TestCase;
 import org.junit.Test;
 
 import java.io.IOException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class DirectEditingOpenFileRemoteOperationIT extends AbstractIT {
     @Test
@@ -37,10 +37,11 @@ public class DirectEditingOpenFileRemoteOperationIT extends AbstractIT {
         TestCase.assertTrue(new ReadFileRemoteOperation(remotePath).execute(client).isSuccess());
 
         // open file
-        RemoteOperationResult result = new DirectEditingOpenFileRemoteOperation(remotePath, "text").execute(client);
+        RemoteOperationResult<String> result = new DirectEditingOpenFileRemoteOperation(remotePath, "text")
+                .execute(nextcloudClient);
         assertTrue(result.isSuccess());
 
-        String url = (String) result.getSingleData();
+        String url = result.getResultData();
 
         assertFalse(url.isEmpty());
     }
@@ -60,10 +61,11 @@ public class DirectEditingOpenFileRemoteOperationIT extends AbstractIT {
         TestCase.assertTrue(new ReadFileRemoteOperation(remotePath).execute(client).isSuccess());
 
         // open file
-        RemoteOperationResult result = new DirectEditingOpenFileRemoteOperation(remotePath, "text").execute(client);
+        RemoteOperationResult<String> result = new DirectEditingOpenFileRemoteOperation(remotePath, "text")
+                .execute(nextcloudClient);
         assertTrue(result.isSuccess());
 
-        String url = (String) result.getSingleData();
+        String url = result.getResultData();
 
         assertFalse(url.isEmpty());
     }
@@ -83,10 +85,11 @@ public class DirectEditingOpenFileRemoteOperationIT extends AbstractIT {
         TestCase.assertTrue(new ReadFileRemoteOperation(remotePath).execute(client).isSuccess());
 
         // open file
-        RemoteOperationResult result = new DirectEditingOpenFileRemoteOperation(remotePath, "text").execute(client);
+        RemoteOperationResult<String> result = new DirectEditingOpenFileRemoteOperation(remotePath, "text")
+                .execute(nextcloudClient);
         assertTrue(result.isSuccess());
 
-        String url = (String) result.getSingleData();
+        String url = result.getResultData();
 
         assertFalse(url.isEmpty());
     }
@@ -98,7 +101,8 @@ public class DirectEditingOpenFileRemoteOperationIT extends AbstractIT {
         TestCase.assertFalse(new ReadFileRemoteOperation(remotePath).execute(client).isSuccess());
 
         // open file
-        RemoteOperationResult result = new DirectEditingOpenFileRemoteOperation(remotePath, "text").execute(client);
+        RemoteOperationResult<String> result = new DirectEditingOpenFileRemoteOperation(remotePath, "text")
+                .execute(nextcloudClient);
         assertFalse(result.isSuccess());
     }
 }

--- a/library/src/main/java/com/nextcloud/android/lib/resources/directediting/DirectEditingCreateFileRemoteOperation.java
+++ b/library/src/main/java/com/nextcloud/android/lib/resources/directediting/DirectEditingCreateFileRemoteOperation.java
@@ -7,13 +7,14 @@
  */
 package com.nextcloud.android.lib.resources.directediting;
 
-import com.owncloud.android.lib.common.OwnCloudClient;
+import com.nextcloud.common.JSONRequestBody;
+import com.nextcloud.common.NextcloudClient;
+import com.nextcloud.operations.PostMethod;
 import com.owncloud.android.lib.common.operations.RemoteOperation;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.lib.common.utils.Log_OC;
 
 import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.methods.Utf8PostMethod;
 import org.json.JSONObject;
 
 /**
@@ -22,8 +23,6 @@ import org.json.JSONObject;
 
 public class DirectEditingCreateFileRemoteOperation extends RemoteOperation<String> {
     private static final String TAG = DirectEditingCreateFileRemoteOperation.class.getSimpleName();
-    private static final int SYNC_READ_TIMEOUT = 40000;
-    private static final int SYNC_CONNECTION_TIMEOUT = 5000;
     private static final String DIRECT_ENDPOINT = "/ocs/v2.php/apps/files/api/v1/directEditing/create";
 
     private final String path;
@@ -45,45 +44,44 @@ public class DirectEditingCreateFileRemoteOperation extends RemoteOperation<Stri
         this(path, editor, creator, "");
     }
 
-    protected RemoteOperationResult<String> run(OwnCloudClient client) {
+    public RemoteOperationResult<String> run(NextcloudClient client) {
         RemoteOperationResult<String> result;
-        Utf8PostMethod postMethod = null;
+        PostMethod post = null;
 
         try {
-            postMethod = new Utf8PostMethod(client.getBaseUri() + DIRECT_ENDPOINT + JSON_FORMAT);
-            postMethod.addParameter("path", path);
-            postMethod.addParameter("editorId", editor);
-            postMethod.addParameter("creatorId", creator);
+            // request body
+            JSONRequestBody jsonRequestBody = new JSONRequestBody("path", path);
+            jsonRequestBody.put("editorId", editor);
+            jsonRequestBody.put("creatorId", creator);
 
             if (!template.isEmpty()) {
-                postMethod.addParameter("templateId", template);
+                jsonRequestBody.put("templateId", template);
             }
 
-            // remote request
-            postMethod.addRequestHeader(OCS_API_HEADER, OCS_API_HEADER_VALUE);
+            // post request
+            post = new PostMethod(client.getBaseUri() + DIRECT_ENDPOINT + JSON_FORMAT, true, jsonRequestBody.get());
 
-            int status = client.executeMethod(postMethod, SYNC_READ_TIMEOUT, SYNC_CONNECTION_TIMEOUT);
+            int status = client.execute(post);
 
             if (status == HttpStatus.SC_OK) {
-                String response = postMethod.getResponseBodyAsString();
+                String response = post.getResponseBodyAsString();
 
                 // Parse the response
                 JSONObject respJSON = new JSONObject(response);
                 String url = (String) respJSON.getJSONObject("ocs").getJSONObject("data").get("url");
 
-                result = new RemoteOperationResult<>(true, postMethod);
+                result = new RemoteOperationResult<>(true, post);
                 result.setResultData(url);
             } else {
-                result = new RemoteOperationResult<>(false, postMethod);
-                client.exhaustResponse(postMethod.getResponseBodyAsStream());
+                result = new RemoteOperationResult<>(false, post);
             }
         } catch (Exception e) {
             result = new RemoteOperationResult<>(e);
             Log_OC.e(TAG, "Get all direct editing information failed: " + result.getLogMessage(),
                     result.getException());
         } finally {
-            if (postMethod != null) {
-                postMethod.releaseConnection();
+            if (post != null) {
+                post.releaseConnection();
             }
         }
         return result;

--- a/library/src/main/java/com/nextcloud/android/lib/resources/directediting/DirectEditingCreateFileRemoteOperation.java
+++ b/library/src/main/java/com/nextcloud/android/lib/resources/directediting/DirectEditingCreateFileRemoteOperation.java
@@ -14,7 +14,6 @@ import com.owncloud.android.lib.common.operations.RemoteOperation;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.lib.common.utils.Log_OC;
 
-import org.apache.commons.httpclient.HttpStatus;
 import org.json.JSONObject;
 
 /**
@@ -61,9 +60,9 @@ public class DirectEditingCreateFileRemoteOperation extends RemoteOperation<Stri
             // post request
             post = new PostMethod(client.getBaseUri() + DIRECT_ENDPOINT + JSON_FORMAT, true, jsonRequestBody.get());
 
-            int status = client.execute(post);
+            client.execute(post);
 
-            if (status == HttpStatus.SC_OK) {
+            if (post.isSuccess()) {
                 String response = post.getResponseBodyAsString();
 
                 // Parse the response

--- a/library/src/main/java/com/nextcloud/android/lib/resources/directediting/DirectEditingObtainListOfTemplatesRemoteOperation.java
+++ b/library/src/main/java/com/nextcloud/android/lib/resources/directediting/DirectEditingObtainListOfTemplatesRemoteOperation.java
@@ -36,7 +36,7 @@ public class DirectEditingObtainListOfTemplatesRemoteOperation extends OCSRemote
 
     public RemoteOperationResult<TemplateList> run(NextcloudClient client) {
         RemoteOperationResult<TemplateList> result;
-        com.nextcloud.operations.GetMethod get = null;
+        GetMethod get = null;
 
         try {
             // get request

--- a/library/src/main/java/com/nextcloud/android/lib/resources/directediting/DirectEditingObtainListOfTemplatesRemoteOperation.java
+++ b/library/src/main/java/com/nextcloud/android/lib/resources/directediting/DirectEditingObtainListOfTemplatesRemoteOperation.java
@@ -16,8 +16,6 @@ import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.lib.ocs.ServerResponse;
 import com.owncloud.android.lib.resources.OCSRemoteOperation;
 
-import org.apache.commons.httpclient.HttpStatus;
-
 /**
  * Get templates for an editor
  */
@@ -42,9 +40,9 @@ public class DirectEditingObtainListOfTemplatesRemoteOperation extends OCSRemote
             // get request
             get = new GetMethod(client.getBaseUri() + DIRECT_ENDPOINT + editor + "/" + template + JSON_FORMAT, true);
 
-            int status = client.execute(get);
+            client.execute(get);
 
-            if (status == HttpStatus.SC_OK) {
+            if (get.isSuccess()) {
                 ServerResponse<TemplateList> serverResponse = getServerResponse(get, new TypeToken<>() {});
 
                 if (serverResponse != null) {

--- a/library/src/main/java/com/nextcloud/android/lib/resources/directediting/DirectEditingObtainListOfTemplatesRemoteOperation.java
+++ b/library/src/main/java/com/nextcloud/android/lib/resources/directediting/DirectEditingObtainListOfTemplatesRemoteOperation.java
@@ -8,7 +8,8 @@
 package com.nextcloud.android.lib.resources.directediting;
 
 import com.google.gson.reflect.TypeToken;
-import com.owncloud.android.lib.common.OwnCloudClient;
+import com.nextcloud.common.NextcloudClient;
+import com.nextcloud.operations.GetMethod;
 import com.owncloud.android.lib.common.TemplateList;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.lib.common.utils.Log_OC;
@@ -16,7 +17,6 @@ import com.owncloud.android.lib.ocs.ServerResponse;
 import com.owncloud.android.lib.resources.OCSRemoteOperation;
 
 import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.methods.GetMethod;
 
 /**
  * Get templates for an editor
@@ -24,8 +24,6 @@ import org.apache.commons.httpclient.methods.GetMethod;
 
 public class DirectEditingObtainListOfTemplatesRemoteOperation extends OCSRemoteOperation<TemplateList> {
     private static final String TAG = DirectEditingObtainListOfTemplatesRemoteOperation.class.getSimpleName();
-    private static final int SYNC_READ_TIMEOUT = 40000;
-    private static final int SYNC_CONNECTION_TIMEOUT = 5000;
     private static final String DIRECT_ENDPOINT = "/ocs/v2.php/apps/files/api/v1/directEditing/templates/";
 
     private final String editor;
@@ -36,39 +34,36 @@ public class DirectEditingObtainListOfTemplatesRemoteOperation extends OCSRemote
         this.template = template;
     }
 
-    protected RemoteOperationResult<TemplateList> run(OwnCloudClient client) {
+    public RemoteOperationResult<TemplateList> run(NextcloudClient client) {
         RemoteOperationResult<TemplateList> result;
-        GetMethod getMethod = null;
+        com.nextcloud.operations.GetMethod get = null;
 
         try {
-            getMethod = new GetMethod(client.getBaseUri() + DIRECT_ENDPOINT + editor + "/" + template + JSON_FORMAT);
+            // get request
+            get = new GetMethod(client.getBaseUri() + DIRECT_ENDPOINT + editor + "/" + template + JSON_FORMAT, true);
 
-            // remote request
-            getMethod.addRequestHeader(OCS_API_HEADER, OCS_API_HEADER_VALUE);
-
-            int status = client.executeMethod(getMethod, SYNC_READ_TIMEOUT, SYNC_CONNECTION_TIMEOUT);
+            int status = client.execute(get);
 
             if (status == HttpStatus.SC_OK) {
-                ServerResponse<TemplateList> serverResponse = getServerResponse(getMethod, new TypeToken<>() {});
+                ServerResponse<TemplateList> serverResponse = getServerResponse(get, new TypeToken<>() {});
 
                 if (serverResponse != null) {
                     TemplateList templateList = serverResponse.getOcs().getData();
-                    result = new RemoteOperationResult<>(true, getMethod);
+                    result = new RemoteOperationResult<>(true, get);
                     result.setResultData(templateList);
                 } else {
-                    result = new RemoteOperationResult<>(false, getMethod);
+                    result = new RemoteOperationResult<>(false, get);
                 }
             } else {
-                result = new RemoteOperationResult<>(false, getMethod);
-                client.exhaustResponse(getMethod.getResponseBodyAsStream());
+                result = new RemoteOperationResult<>(false, get);
             }
         } catch (Exception e) {
             result = new RemoteOperationResult<>(e);
             Log_OC.e(TAG, "Get all direct editing information failed: " + result.getLogMessage(),
                      result.getException());
         } finally {
-            if (getMethod != null) {
-                getMethod.releaseConnection();
+            if (get != null) {
+                get.releaseConnection();
             }
         }
 

--- a/library/src/main/java/com/nextcloud/android/lib/resources/directediting/DirectEditingObtainRemoteOperation.java
+++ b/library/src/main/java/com/nextcloud/android/lib/resources/directediting/DirectEditingObtainRemoteOperation.java
@@ -28,7 +28,7 @@ public class DirectEditingObtainRemoteOperation extends OCSRemoteOperation<Direc
 
     public RemoteOperationResult<DirectEditing> run(NextcloudClient client) {
         RemoteOperationResult<DirectEditing> result;
-        com.nextcloud.operations.GetMethod getMethod = null;
+        GetMethod getMethod = null;
 
         try {
             getMethod = new GetMethod(client.getBaseUri() + DIRECT_ENDPOINT + JSON_FORMAT, true);

--- a/library/src/main/java/com/nextcloud/android/lib/resources/directediting/DirectEditingObtainRemoteOperation.java
+++ b/library/src/main/java/com/nextcloud/android/lib/resources/directediting/DirectEditingObtainRemoteOperation.java
@@ -16,8 +16,6 @@ import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.lib.ocs.ServerResponse;
 import com.owncloud.android.lib.resources.OCSRemoteOperation;
 
-import org.apache.commons.httpclient.HttpStatus;
-
 /**
  * Get all editor details from direct editing
  */
@@ -33,9 +31,9 @@ public class DirectEditingObtainRemoteOperation extends OCSRemoteOperation<Direc
         try {
             getMethod = new GetMethod(client.getBaseUri() + DIRECT_ENDPOINT + JSON_FORMAT, true);
 
-            int status = client.execute(getMethod);
+            client.execute(getMethod);
 
-            if (status == HttpStatus.SC_OK) {
+            if (getMethod.isSuccess()) {
                 ServerResponse<DirectEditing> serverResponse = getServerResponse(getMethod,
                         new TypeToken<>() {
                         });

--- a/library/src/main/java/com/nextcloud/android/lib/resources/directediting/DirectEditingObtainRemoteOperation.java
+++ b/library/src/main/java/com/nextcloud/android/lib/resources/directediting/DirectEditingObtainRemoteOperation.java
@@ -8,15 +8,15 @@
 package com.nextcloud.android.lib.resources.directediting;
 
 import com.google.gson.reflect.TypeToken;
+import com.nextcloud.common.NextcloudClient;
+import com.nextcloud.operations.GetMethod;
 import com.owncloud.android.lib.common.DirectEditing;
-import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.lib.ocs.ServerResponse;
 import com.owncloud.android.lib.resources.OCSRemoteOperation;
 
 import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.methods.GetMethod;
 
 /**
  * Get all editor details from direct editing
@@ -24,21 +24,16 @@ import org.apache.commons.httpclient.methods.GetMethod;
 
 public class DirectEditingObtainRemoteOperation extends OCSRemoteOperation<DirectEditing> {
     private static final String TAG = DirectEditingObtainRemoteOperation.class.getSimpleName();
-    private static final int SYNC_READ_TIMEOUT = 40000;
-    private static final int SYNC_CONNECTION_TIMEOUT = 5000;
     private static final String DIRECT_ENDPOINT = "/ocs/v2.php/apps/files/api/v1/directEditing";
 
-    protected RemoteOperationResult<DirectEditing> run(OwnCloudClient client) {
+    public RemoteOperationResult<DirectEditing> run(NextcloudClient client) {
         RemoteOperationResult<DirectEditing> result;
-        GetMethod getMethod = null;
+        com.nextcloud.operations.GetMethod getMethod = null;
 
         try {
-            getMethod = new GetMethod(client.getBaseUri() + DIRECT_ENDPOINT + JSON_FORMAT);
+            getMethod = new GetMethod(client.getBaseUri() + DIRECT_ENDPOINT + JSON_FORMAT, true);
 
-            // remote request
-            getMethod.addRequestHeader(OCS_API_HEADER, OCS_API_HEADER_VALUE);
-
-            int status = client.executeMethod(getMethod, SYNC_READ_TIMEOUT, SYNC_CONNECTION_TIMEOUT);
+            int status = client.execute(getMethod);
 
             if (status == HttpStatus.SC_OK) {
                 ServerResponse<DirectEditing> serverResponse = getServerResponse(getMethod,
@@ -55,11 +50,10 @@ public class DirectEditingObtainRemoteOperation extends OCSRemoteOperation<Direc
 
             } else {
                 result = new RemoteOperationResult<>(false, getMethod);
-                client.exhaustResponse(getMethod.getResponseBodyAsStream());
             }
         } catch (Exception e) {
             result = new RemoteOperationResult<>(e);
-            Log_OC.e(TAG, "Get all direct editing informations failed: " + result.getLogMessage(),
+            Log_OC.e(TAG, "Get all direct editing information failed: " + result.getLogMessage(),
                      result.getException());
         } finally {
             if (getMethod != null) {

--- a/library/src/main/java/com/nextcloud/android/lib/resources/directediting/DirectEditingOpenFileRemoteOperation.java
+++ b/library/src/main/java/com/nextcloud/android/lib/resources/directediting/DirectEditingOpenFileRemoteOperation.java
@@ -14,7 +14,6 @@ import com.owncloud.android.lib.common.operations.RemoteOperation;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.lib.common.utils.Log_OC;
 
-import org.apache.commons.httpclient.HttpStatus;
 import org.json.JSONObject;
 
 /**
@@ -46,9 +45,9 @@ public class DirectEditingOpenFileRemoteOperation extends RemoteOperation<String
             postMethod = new PostMethod(client.getBaseUri() + DIRECT_ENDPOINT + JSON_FORMAT, true,
                                         jsonRequestBody.get());
 
-            int status = client.execute(postMethod);
+            client.execute(postMethod);
 
-            if (status == HttpStatus.SC_OK) {
+            if (postMethod.isSuccess()) {
                 String response = postMethod.getResponseBodyAsString();
 
                 // Parse the response

--- a/library/src/main/java/com/nextcloud/android/lib/resources/directediting/DirectEditingOpenFileRemoteOperation.java
+++ b/library/src/main/java/com/nextcloud/android/lib/resources/directediting/DirectEditingOpenFileRemoteOperation.java
@@ -7,23 +7,22 @@
  */
 package com.nextcloud.android.lib.resources.directediting;
 
-import com.owncloud.android.lib.common.OwnCloudClient;
+import com.nextcloud.common.JSONRequestBody;
+import com.nextcloud.common.NextcloudClient;
+import com.nextcloud.operations.PostMethod;
 import com.owncloud.android.lib.common.operations.RemoteOperation;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.lib.common.utils.Log_OC;
 
 import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.methods.Utf8PostMethod;
 import org.json.JSONObject;
 
 /**
  * open file for direct editing
  */
 
-public class DirectEditingOpenFileRemoteOperation extends RemoteOperation {
+public class DirectEditingOpenFileRemoteOperation extends RemoteOperation<String> {
     private static final String TAG = DirectEditingOpenFileRemoteOperation.class.getSimpleName();
-    private static final int SYNC_READ_TIMEOUT = 40000;
-    private static final int SYNC_CONNECTION_TIMEOUT = 5000;
     private static final String DIRECT_ENDPOINT = "/ocs/v2.php/apps/files/api/v1/directEditing/open";
 
     private final String filePath;
@@ -34,19 +33,20 @@ public class DirectEditingOpenFileRemoteOperation extends RemoteOperation {
         this.editor = editor;
     }
 
-    protected RemoteOperationResult run(OwnCloudClient client) {
-        RemoteOperationResult result;
-        Utf8PostMethod postMethod = null;
+    public RemoteOperationResult<String> run(NextcloudClient client) {
+        RemoteOperationResult<String> result;
+        PostMethod postMethod = null;
 
         try {
-            postMethod = new Utf8PostMethod(client.getBaseUri() + DIRECT_ENDPOINT + JSON_FORMAT);
-            postMethod.addParameter("path", filePath);
-            postMethod.addParameter("editorId", editor);
+            // request body
+            JSONRequestBody jsonRequestBody = new JSONRequestBody("path", filePath);
+            jsonRequestBody.put("editorId", editor);
 
-            // remote request
-            postMethod.addRequestHeader(OCS_API_HEADER, OCS_API_HEADER_VALUE);
+            // post request
+            postMethod = new PostMethod(client.getBaseUri() + DIRECT_ENDPOINT + JSON_FORMAT, true,
+                                        jsonRequestBody.get());
 
-            int status = client.executeMethod(postMethod, SYNC_READ_TIMEOUT, SYNC_CONNECTION_TIMEOUT);
+            int status = client.execute(postMethod);
 
             if (status == HttpStatus.SC_OK) {
                 String response = postMethod.getResponseBodyAsString();
@@ -55,15 +55,14 @@ public class DirectEditingOpenFileRemoteOperation extends RemoteOperation {
                 JSONObject respJSON = new JSONObject(response);
                 String url = (String) respJSON.getJSONObject("ocs").getJSONObject("data").get("url");
 
-                result = new RemoteOperationResult(true, postMethod);
-                result.setSingleData(url);
+                result = new RemoteOperationResult<>(true, postMethod);
+                result.setResultData(url);
             } else {
-                result = new RemoteOperationResult(false, postMethod);
-                client.exhaustResponse(postMethod.getResponseBodyAsStream());
+                result = new RemoteOperationResult<>(false, postMethod);
             }
         } catch (Exception e) {
-            result = new RemoteOperationResult(e);
-            Log_OC.e(TAG, "Get all direct editing informations failed: " + result.getLogMessage(),
+            result = new RemoteOperationResult<>(e);
+            Log_OC.e(TAG, "Get all direct editing information failed: " + result.getLogMessage(),
                      result.getException());
         } finally {
             if (postMethod != null) {


### PR DESCRIPTION
This is one of a series of pull requests which aim to replace all instances of `OwnCloudClient` with `NextcloudClient`. The reason for this change is that the newer `NextcloudClient` uses OkHttp, replacing the outdated Jackrabbit methods.

Specifically, this pull request implements the following:
- changes related to direct editing
- see #1271