### PR TITLE
Deprecate OwncloudClient - Sharing

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,14 +1,14 @@
-import com.github.spotbugs.snom.SpotBugsTask
 import com.github.spotbugs.snom.Confidence
 import com.github.spotbugs.snom.Effort
+import com.github.spotbugs.snom.SpotBugsTask
 
 buildscript {
     ext {
         junit_version = '4.13.2'
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.2.1'
-        classpath 'com.github.spotbugs.snom:spotbugs-gradle-plugin:6.0.6'
+        classpath 'com.android.tools.build:gradle:8.2.0'
+        classpath 'com.github.spotbugs.snom:spotbugs-gradle-plugin:6.0.5'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.4"
         classpath "org.jacoco:org.jacoco.core:$jacoco_version"

--- a/library/src/androidTest/java/com/nextcloud/android/lib/resources/dashboard/DashboardGetWidgetItemsRemoteOperationIT.kt
+++ b/library/src/androidTest/java/com/nextcloud/android/lib/resources/dashboard/DashboardGetWidgetItemsRemoteOperationIT.kt
@@ -38,7 +38,7 @@ class DashboardGetWidgetItemsRemoteOperationIT : AbstractIT() {
         testOnlyOnServer(NextcloudVersion.nextcloud_25)
 
         // create folder to have some content
-        assertTrue(CreateFolderRemoteOperation("/testFolder", false).execute(client2).isSuccess)
+        assertTrue(CreateFolderRemoteOperation("/testFolder", false).execute(nextcloudClient2).isSuccess)
         assertTrue(
             CreateShareRemoteOperation(
                 "/testFolder",
@@ -47,7 +47,7 @@ class DashboardGetWidgetItemsRemoteOperationIT : AbstractIT() {
                 false,
                 "",
                 OCShare.MAXIMUM_PERMISSIONS_FOR_FOLDER
-            ).execute(client2)
+            ).execute(nextcloudClient2)
                 .isSuccess
         )
 

--- a/library/src/androidTest/java/com/owncloud/android/AbstractIT.java
+++ b/library/src/androidTest/java/com/owncloud/android/AbstractIT.java
@@ -26,16 +26,9 @@
  */
 package com.owncloud.android;
 
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeTrue;
-
 import android.content.Context;
 import android.net.Uri;
 import android.os.Bundle;
-
-import androidx.test.platform.app.InstrumentationRegistry;
 
 import com.nextcloud.common.NextcloudClient;
 import com.owncloud.android.lib.common.OwnCloudBasicCredentials;
@@ -73,7 +66,13 @@ import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 
+import androidx.test.platform.app.InstrumentationRegistry;
 import okhttp3.Credentials;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
 
 /**
  * Common base for all integration tests
@@ -90,6 +89,7 @@ public abstract class AbstractIT {
     public static OwnCloudClient client;
     public static OwnCloudClient client2;
     protected static NextcloudClient nextcloudClient;
+    protected static NextcloudClient nextcloudClient2;
     protected static Context context;
     protected static Uri url;
 
@@ -128,6 +128,10 @@ public abstract class AbstractIT {
         String userId = loginName; // for test same as userId
         String credentials = Credentials.basic(loginName, password);
         nextcloudClient = new NextcloudClient(url, userId, credentials, context);
+
+        String userId2 = loginName; // for test same as userId
+        String credentials2 = Credentials.basic(loginName2, password2);
+        nextcloudClient2 = new NextcloudClient(url, userId2, credentials2, context);
 
         waitForServer(client, url);
         testConnection();

--- a/library/src/androidTest/java/com/owncloud/android/FileIT.java
+++ b/library/src/androidTest/java/com/owncloud/android/FileIT.java
@@ -26,10 +26,6 @@
  */
 package com.owncloud.android;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import android.net.Uri;
 
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
@@ -49,6 +45,10 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests related to file operations
@@ -145,7 +145,7 @@ public class FileIT extends AbstractIT {
                                                   false,
                                                   "",
                                                   OCShare.NO_PERMISSION)
-                           .execute(client).isSuccess());
+                           .execute(nextcloudClient).isSuccess());
 
         // verify
         RemoteOperationResult result = new ReadFolderRemoteOperation("/").execute(client);
@@ -186,7 +186,7 @@ public class FileIT extends AbstractIT {
                 false,
                 "",
                 OCShare.NO_PERMISSION)
-                .execute(client).isSuccess());
+                .execute(nextcloudClient).isSuccess());
 
         // verify
         RemoteOperationResult result = new ReadFolderRemoteOperation("/").execute(client);
@@ -221,7 +221,7 @@ public class FileIT extends AbstractIT {
                                                   false,
                                                   "",
                                                   OCShare.NO_PERMISSION)
-                           .execute(client).isSuccess());
+                           .execute(nextcloudClient).isSuccess());
 
         // verify
         RemoteOperationResult result = new ReadFolderRemoteOperation("/").execute(client);
@@ -258,7 +258,7 @@ public class FileIT extends AbstractIT {
                                                   false,
                                                   "",
                                                   OCShare.NO_PERMISSION)
-                           .execute(client).isSuccess());
+                           .execute(nextcloudClient).isSuccess());
 
         assertTrue(new CreateShareRemoteOperation(path,
                                                   ShareType.USER,
@@ -266,7 +266,7 @@ public class FileIT extends AbstractIT {
                                                   false,
                                                   "",
                                                   OCShare.NO_PERMISSION)
-                           .execute(client).isSuccess());
+                           .execute(nextcloudClient).isSuccess());
 
         // verify
         RemoteOperationResult result = new ReadFolderRemoteOperation("/").execute(client);
@@ -306,7 +306,7 @@ public class FileIT extends AbstractIT {
                                                   false,
                                                   "",
                                                   OCShare.NO_PERMISSION)
-                           .execute(client).isSuccess());
+                           .execute(nextcloudClient).isSuccess());
 
         assertTrue(new CreateShareRemoteOperation(path,
                                                   ShareType.USER,
@@ -314,7 +314,7 @@ public class FileIT extends AbstractIT {
                                                   false,
                                                   "",
                                                   OCShare.NO_PERMISSION)
-                           .execute(client).isSuccess());
+                           .execute(nextcloudClient).isSuccess());
 
         // verify
         RemoteOperationResult result = new ReadFolderRemoteOperation(path).execute(client);

--- a/library/src/androidTest/java/com/owncloud/android/lib/common/operations/CreateShareIT.java
+++ b/library/src/androidTest/java/com/owncloud/android/lib/common/operations/CreateShareIT.java
@@ -26,10 +26,6 @@
  */
 package com.owncloud.android.lib.common.operations;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import com.owncloud.android.AbstractIT;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult.ResultCode;
 import com.owncloud.android.lib.resources.files.UploadFileRemoteOperation;
@@ -40,6 +36,10 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test create share
@@ -75,7 +75,7 @@ public class CreateShareIT extends AbstractIT {
                 "",
                 false,
                 "",
-                1).execute(client);
+                1).execute(nextcloudClient);
         assertTrue(result.isSuccess());
     }
 
@@ -86,7 +86,7 @@ public class CreateShareIT extends AbstractIT {
                 "",
                 false,
                 "",
-                1).execute(client);
+                1).execute(nextcloudClient);
 
         assertFalse(result.isSuccess());
         assertEquals(ResultCode.FILE_NOT_FOUND, result.getCode());
@@ -102,7 +102,7 @@ public class CreateShareIT extends AbstractIT {
                 "admin",
                 false,
                 "",
-                31).execute(client);
+                31).execute(nextcloudClient);
         assertTrue(result.isSuccess());
     }
 
@@ -116,7 +116,7 @@ public class CreateShareIT extends AbstractIT {
                 "no_exist",
                 false,
                 "",
-                31).execute(client);
+                31).execute(nextcloudClient);
         assertFalse(result.isSuccess());
 
         // TODO 404 is File not found, but actually it is "user not found"
@@ -133,7 +133,7 @@ public class CreateShareIT extends AbstractIT {
                 "admin",
                 false,
                 "",
-                31).execute(client);
+                31).execute(nextcloudClient);
         assertFalse(result.isSuccess());
         assertEquals(ResultCode.FILE_NOT_FOUND, result.getCode());
     }
@@ -148,7 +148,7 @@ public class CreateShareIT extends AbstractIT {
                 "admin",
                 false,
                 "",
-                1).execute(client);
+                1).execute(nextcloudClient);
         assertTrue(result.isSuccess());
     }
 
@@ -162,7 +162,7 @@ public class CreateShareIT extends AbstractIT {
                 "no_exist",
                 false,
                 "",
-                31).execute(client);
+                31).execute(nextcloudClient);
         assertFalse(result.isSuccess());
 
         // TODO 404 is File not found, but actually it is "user not found"
@@ -179,7 +179,7 @@ public class CreateShareIT extends AbstractIT {
                 "admin",
                 false,
                 "",
-                31).execute(client);
+                31).execute(nextcloudClient);
         assertFalse(result.isSuccess());
         assertEquals(ResultCode.FILE_NOT_FOUND, result.getCode());
     }
@@ -208,7 +208,7 @@ public class CreateShareIT extends AbstractIT {
                 "no_exist@" + serverUri2,
                 false,
                 "",
-                31).execute(client);
+                31).execute(nextcloudClient);
 
         assertFalse("sharee doesn't exist in an existing remote server", result.isSuccess());
         assertEquals("sharee doesn't exist in an existing remote server, forbidden",
@@ -225,7 +225,7 @@ public class CreateShareIT extends AbstractIT {
                 "no_exist",
                 false,
                 "",
-                31).execute(client);
+                31).execute(nextcloudClient);
         assertFalse(result.isSuccess());
         // TODO expected:<SHARE_WRONG_PARAMETER> but was:<SHARE_FORBIDDEN>
         assertEquals("remote server doesn't exist", ResultCode.SHARE_FORBIDDEN, result.getCode());
@@ -241,7 +241,7 @@ public class CreateShareIT extends AbstractIT {
                 "admin@" + serverUri2,
                 false,
                 "",
-                31).execute(client);
+                31).execute(nextcloudClient);
 
         assertFalse("file doesn't exist", result.isSuccess());
         assertEquals("file doesn't exist", ResultCode.FILE_NOT_FOUND, result.getCode());

--- a/library/src/androidTest/java/com/owncloud/android/lib/common/operations/GetSharesIT.java
+++ b/library/src/androidTest/java/com/owncloud/android/lib/common/operations/GetSharesIT.java
@@ -26,9 +26,6 @@
  */
 package com.owncloud.android.lib.common.operations;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import com.owncloud.android.AbstractIT;
 import com.owncloud.android.lib.resources.files.CreateFolderRemoteOperation;
 import com.owncloud.android.lib.resources.shares.CreateShareRemoteOperation;
@@ -39,6 +36,9 @@ import com.owncloud.android.lib.resources.shares.ShareType;
 import org.junit.Test;
 
 import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Class to test Get Shares Operation
@@ -55,7 +55,7 @@ public class GetSharesIT extends AbstractIT {
                 "",
                 false,
                 "",
-                1).execute(client).isSuccess());
+                1).execute(nextcloudClient).isSuccess());
 
         assertTrue(new CreateFolderRemoteOperation("/2/", true).execute(client).isSuccess());
         assertTrue(new CreateShareRemoteOperation("/2/",
@@ -63,9 +63,9 @@ public class GetSharesIT extends AbstractIT {
                 "",
                 false,
                 "",
-                1).execute(client).isSuccess());
+                1).execute(nextcloudClient).isSuccess());
 
-        RemoteOperationResult<List<OCShare>> result = new GetSharesRemoteOperation().execute(client);
+        RemoteOperationResult<List<OCShare>> result = new GetSharesRemoteOperation().execute(nextcloudClient);
         assertTrue(result.isSuccess());
         assertEquals(2, result.getResultData().size());
         assertEquals("/1/", result.getResultData().get(0).getPath());

--- a/library/src/androidTest/java/com/owncloud/android/lib/common/operations/RemoveShareIT.java
+++ b/library/src/androidTest/java/com/owncloud/android/lib/common/operations/RemoveShareIT.java
@@ -26,8 +26,6 @@
  */
 package com.owncloud.android.lib.common.operations;
 
-import static org.junit.Assert.assertTrue;
-
 import com.owncloud.android.AbstractIT;
 import com.owncloud.android.lib.resources.files.UploadFileRemoteOperation;
 import com.owncloud.android.lib.resources.shares.CreateShareRemoteOperation;
@@ -40,6 +38,8 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+
+import static org.junit.Assert.assertTrue;
 
 public class RemoveShareIT extends AbstractIT {
     private static final String FILE_TO_UNSHARE = "/fileToUnshare.txt";
@@ -61,7 +61,7 @@ public class RemoveShareIT extends AbstractIT {
                 ShareType.PUBLIC_LINK,
                 "",
                 false,
-                "", 1).execute(client);
+                "", 1).execute(nextcloudClient);
 
         assertTrue(result.isSuccess());
 

--- a/library/src/androidTest/java/com/owncloud/android/lib/resources/files/SearchRemoteOperationIT.java
+++ b/library/src/androidTest/java/com/owncloud/android/lib/resources/files/SearchRemoteOperationIT.java
@@ -26,13 +26,8 @@
  */
 package com.owncloud.android.lib.resources.files;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertTrue;
-
 import android.net.Uri;
 import android.os.Bundle;
-
-import androidx.test.platform.app.InstrumentationRegistry;
 
 import com.owncloud.android.AbstractIT;
 import com.owncloud.android.lib.common.OwnCloudBasicCredentials;
@@ -50,6 +45,11 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.List;
+
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
 
 public class SearchRemoteOperationIT extends AbstractIT {
     private static OCCapability capability;
@@ -196,7 +196,7 @@ public class SearchRemoteOperationIT extends AbstractIT {
                 client.getUserId(),
                 false,
                 "",
-                31).execute(client2)
+                31).execute(nextcloudClient2)
                 .isSuccess()
         );
 

--- a/library/src/androidTest/java/com/owncloud/android/lib/resources/shares/CreateShareRemoteOperationIT.kt
+++ b/library/src/androidTest/java/com/owncloud/android/lib/resources/shares/CreateShareRemoteOperationIT.kt
@@ -70,7 +70,7 @@ class CreateShareRemoteOperationIT : AbstractIT() {
                 OCShare.MAXIMUM_PERMISSIONS_FOR_FOLDER,
                 true,
                 note
-            ).execute(client)
+            ).execute(nextcloudClient)
 
         junit.framework.Assert.assertTrue(sut.isSuccess)
 

--- a/library/src/androidTest/java/com/owncloud/android/lib/resources/shares/UpdateShareRemoteOperationIT.kt
+++ b/library/src/androidTest/java/com/owncloud/android/lib/resources/shares/UpdateShareRemoteOperationIT.kt
@@ -72,7 +72,7 @@ class UpdateShareRemoteOperationIT : AbstractIT() {
                 OCShare.MAXIMUM_PERMISSIONS_FOR_FOLDER,
                 true,
                 ""
-            ).execute(client)
+            ).execute(nextcloudClient)
 
         assertTrue(createOperationResult.isSuccess)
 
@@ -81,10 +81,10 @@ class UpdateShareRemoteOperationIT : AbstractIT() {
         val sut = UpdateShareRemoteOperation(share.remoteId)
         sut.setNote(note)
 
-        assertTrue(sut.execute(client).isSuccess)
+        assertTrue(sut.execute(nextcloudClient).isSuccess)
 
         // verify
-        val getShareOperationResult = GetShareRemoteOperation(share.remoteId).execute(client)
+        val getShareOperationResult = GetShareRemoteOperation(share.remoteId).execute(nextcloudClient)
         assertTrue(getShareOperationResult.isSuccess)
 
         val updatedShare = getShareOperationResult.resultData[0]
@@ -108,7 +108,7 @@ class UpdateShareRemoteOperationIT : AbstractIT() {
                 true,
                 "",
                 OCShare.READ_PERMISSION_FLAG
-            ).execute(client)
+            ).execute(nextcloudClient)
 
         assertTrue(createOperationResult.isSuccess)
 
@@ -117,10 +117,10 @@ class UpdateShareRemoteOperationIT : AbstractIT() {
         val sut = UpdateShareRemoteOperation(share.remoteId)
         sut.setLabel(label)
 
-        assertTrue(sut.execute(client).isSuccess)
+        assertTrue(sut.execute(nextcloudClient).isSuccess)
 
         // verify
-        val getShareOperationResult = GetShareRemoteOperation(share.remoteId).execute(client)
+        val getShareOperationResult = GetShareRemoteOperation(share.remoteId).execute(nextcloudClient)
         assertTrue(getShareOperationResult.isSuccess)
 
         val updatedShare = getShareOperationResult.resultData[0]
@@ -145,7 +145,7 @@ class UpdateShareRemoteOperationIT : AbstractIT() {
                 true,
                 "",
                 OCShare.READ_PERMISSION_FLAG
-            ).execute(client)
+            ).execute(nextcloudClient)
 
         assertTrue(createOperationResult.isSuccess)
 
@@ -154,7 +154,7 @@ class UpdateShareRemoteOperationIT : AbstractIT() {
         val sut = UpdateShareRemoteOperation(share.remoteId)
         sut.setPassword("1")
 
-        val result = sut.execute(client)
+        val result = sut.execute(nextcloudClient)
         assertFalse(result.isSuccess)
 
         val capabilityResult = GetCapabilitiesRemoteOperation().execute(nextcloudClient)
@@ -195,7 +195,7 @@ class UpdateShareRemoteOperationIT : AbstractIT() {
                 true,
                 "",
                 OCShare.READ_PERMISSION_FLAG
-            ).execute(client)
+            ).execute(nextcloudClient)
 
         assertTrue(createOperationResult.isSuccess)
 
@@ -204,7 +204,7 @@ class UpdateShareRemoteOperationIT : AbstractIT() {
         val sut = UpdateShareRemoteOperation(share.remoteId)
         sut.setPassword("arnservcvcbtp234")
 
-        assertTrue(sut.execute(client).isSuccess)
+        assertTrue(sut.execute(nextcloudClient).isSuccess)
         assertTrue(RemoveFileRemoteOperation(folder).execute(client).isSuccess)
     }
 }

--- a/library/src/main/java/com/nextcloud/common/JSONRequestBody.kt
+++ b/library/src/main/java/com/nextcloud/common/JSONRequestBody.kt
@@ -1,0 +1,31 @@
+package com.nextcloud.common
+
+import com.google.gson.Gson
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
+
+class JSONRequestBody() {
+    private val content = mutableMapOf<String, String>()
+
+    constructor(key: String, value: String) : this() {
+        put(key, value)
+    }
+
+    fun put(key: String, value: String) {
+        content[key] = value
+    }
+
+    fun get(): RequestBody {
+        val json = Gson().toJson(content)
+        return json.toRequestBody(JSON_MEDIATYPE)
+    }
+
+    override fun toString(): String {
+        return content.toString()
+    }
+
+    companion object {
+        private val JSON_MEDIATYPE = "application/json; charset=utf-8".toMediaType()
+    }
+}

--- a/library/src/main/java/com/nextcloud/common/JSONRequestBody.kt
+++ b/library/src/main/java/com/nextcloud/common/JSONRequestBody.kt
@@ -12,7 +12,10 @@ class JSONRequestBody() {
         put(key, value)
     }
 
-    fun put(key: String, value: String) {
+    fun put(
+        key: String,
+        value: String
+    ) {
         content[key] = value
     }
 

--- a/library/src/main/java/com/nextcloud/operations/HeadMethod.kt
+++ b/library/src/main/java/com/nextcloud/operations/HeadMethod.kt
@@ -1,0 +1,43 @@
+/* Nextcloud Android Library is available under MIT license
+ *
+ *   @author ZetaTom
+ *   Copyright (C) 2023 Tobias Kaminsky
+ *   Copyright (C) 2023 Nextcloud GmbH
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining a copy
+ *   of this software and associated documentation files (the "Software"), to deal
+ *   in the Software without restriction, including without limitation the rights
+ *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *   copies of the Software, and to permit persons to whom the Software is
+ *   furnished to do so, subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ *   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ *   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ *   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ *   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *   THE SOFTWARE.
+ *
+ */
+
+package com.nextcloud.operations
+
+import com.nextcloud.common.OkHttpMethodBase
+import okhttp3.Request
+
+/**
+ * HTTP HEAD method that uses OkHttp with new NextcloudClient
+ */
+class HeadMethod(
+    uri: String,
+    useOcsApiRequestHeader: Boolean
+) : OkHttpMethodBase(uri, useOcsApiRequestHeader) {
+    override fun applyType(temp: Request.Builder) {
+        temp.head()
+    }
+}

--- a/library/src/main/java/com/owncloud/android/lib/common/OwnCloudAnonymousCredentials.java
+++ b/library/src/main/java/com/owncloud/android/lib/common/OwnCloudAnonymousCredentials.java
@@ -27,7 +27,7 @@ public class OwnCloudAnonymousCredentials implements OwnCloudCredentials {
 
     @Override
     public String toOkHttpCredentials() {
-        return OkHttpCredentialsUtil.basic(getUsername(), getAuthToken());
+        return OkHttpCredentialsUtil.basic("", "");
     }
 
     @Override

--- a/library/src/main/java/com/owncloud/android/lib/resources/files/ExistenceCheckRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/files/ExistenceCheckRemoteOperation.java
@@ -26,30 +26,25 @@ package com.owncloud.android.lib.resources.files;
 
 import android.content.Context;
 
-import com.owncloud.android.lib.common.OwnCloudAnonymousCredentials;
-import com.owncloud.android.lib.common.OwnCloudClient;
+import com.nextcloud.common.NextcloudClient;
+import com.nextcloud.operations.HeadMethod;
 import com.owncloud.android.lib.common.network.RedirectionPath;
 import com.owncloud.android.lib.common.operations.RemoteOperation;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.lib.common.utils.Log_OC;
 
 import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.methods.HeadMethod;
 
 /**
  * Operation to check the existence or absence of a path in a remote server.
  * 
  * @author David A. Velasco
  */
-public class ExistenceCheckRemoteOperation extends RemoteOperation {
-    
-    /** Maximum time to wait for a response from the server in MILLISECONDs.  */
-    public static final int TIMEOUT = 50000;
-    
+public class ExistenceCheckRemoteOperation extends RemoteOperation<Void> {
     private static final String TAG = ExistenceCheckRemoteOperation.class.getSimpleName();
     
-    private String mPath;
-    private boolean mSuccessIfAbsent;
+    private final String mPath;
+    private final boolean mSuccessIfAbsent;
 
     /** Sequence of redirections followed. Available only after executing the operation */
     private RedirectionPath mRedirectionPath = null;
@@ -81,26 +76,21 @@ public class ExistenceCheckRemoteOperation extends RemoteOperation {
     }
 
     @Override
-	protected RemoteOperationResult run(OwnCloudClient client) {
-        RemoteOperationResult result = null;
-        HeadMethod head = null;
-        boolean previousFollowRedirects = client.isFollowRedirects();
+	public RemoteOperationResult<Void> run(NextcloudClient client) {
+        RemoteOperationResult<Void> result;
+        com.nextcloud.operations.HeadMethod head = null;
+        boolean previousFollowRedirects = client.getFollowRedirects();
         try {
-            if (client.getCredentials() instanceof OwnCloudAnonymousCredentials) {
-                head = new HeadMethod(client.getDavUri().toString());
-            } else {
-                head = new HeadMethod(client.getFilesDavUri(mPath));
-            }
+            head = new HeadMethod(client.getFilesDavUri(mPath), false);
             client.setFollowRedirects(false);
-            int status = client.executeMethod(head, TIMEOUT, TIMEOUT);
+            int status = client.execute(head);
             if (previousFollowRedirects) {
                 mRedirectionPath = client.followRedirection(head);
                 status = mRedirectionPath.getLastStatus();
             }
-            client.exhaustResponse(head.getResponseBodyAsStream());
             boolean success = (status == HttpStatus.SC_OK && !mSuccessIfAbsent) ||
                     (status == HttpStatus.SC_NOT_FOUND && mSuccessIfAbsent);
-            result = new RemoteOperationResult(
+            result = new RemoteOperationResult<>(
                 success,
                 status,
                 head.getStatusText(),
@@ -111,7 +101,7 @@ public class ExistenceCheckRemoteOperation extends RemoteOperation {
                     "finished with HTTP status " + status + (!success ? "(FAIL)" : ""));
             
         } catch (Exception e) {
-            result = new RemoteOperationResult(e);
+            result = new RemoteOperationResult<>(e);
             Log_OC.e(TAG, "Existence check for " + client.getFilesDavUri(mPath) + " targeting for " +
                     (mSuccessIfAbsent ? " absence " : " existence ") + ": " +
                     result.getLogMessage(), result.getException());

--- a/library/src/main/java/com/owncloud/android/lib/resources/shares/CreateShareRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/shares/CreateShareRemoteOperation.java
@@ -28,13 +28,14 @@ package com.owncloud.android.lib.resources.shares;
 
 import android.text.TextUtils;
 
-import com.owncloud.android.lib.common.OwnCloudClient;
+import com.nextcloud.common.JSONRequestBody;
+import com.nextcloud.common.NextcloudClient;
+import com.nextcloud.operations.PostMethod;
 import com.owncloud.android.lib.common.operations.RemoteOperation;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.lib.common.utils.Log_OC;
 
 import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.methods.Utf8PostMethod;
 
 import java.io.IOException;
 import java.util.List;
@@ -61,7 +62,7 @@ public class CreateShareRemoteOperation extends RemoteOperation<List<OCShare>> {
     private final String password;
     private final int permissions;
     private boolean getShareDetails;
-    private String note;
+    private final String note;
 
     /**
      * Constructor
@@ -145,45 +146,44 @@ public class CreateShareRemoteOperation extends RemoteOperation<List<OCShare>> {
     }
 
     @Override
-    protected RemoteOperationResult<List<OCShare>> run(OwnCloudClient client) {
+    public RemoteOperationResult<List<OCShare>> run(NextcloudClient client) {
         RemoteOperationResult<List<OCShare>> result;
         int status;
 
-        Utf8PostMethod post = null;
+        PostMethod post = null;
 
         try {
-            // Post Method
-            post = new Utf8PostMethod(client.getBaseUri() + ShareUtils.SHARING_API_PATH);
+            // request body
+            JSONRequestBody jsonRequestBody = new JSONRequestBody();
 
-            post.setRequestHeader(CONTENT_TYPE, FORM_URLENCODED);
-
-            post.addParameter(PARAM_PATH, remoteFilePath);
-            post.addParameter(PARAM_SHARE_TYPE, Integer.toString(shareType.getValue()));
-            post.addParameter(PARAM_SHARE_WITH, shareWith);
+            jsonRequestBody.put(PARAM_PATH, remoteFilePath);
+            jsonRequestBody.put(PARAM_SHARE_TYPE, Integer.toString(shareType.getValue()));
+            jsonRequestBody.put(PARAM_SHARE_WITH, shareWith);
             if (publicUpload) {
-                post.addParameter(PARAM_PUBLIC_UPLOAD, Boolean.toString(true));
+                jsonRequestBody.put(PARAM_PUBLIC_UPLOAD, Boolean.toString(true));
             }
             if (password != null && password.length() > 0) {
-                post.addParameter(PARAM_PASSWORD, password);
+                jsonRequestBody.put(PARAM_PASSWORD, password);
             }
             if (OCShare.NO_PERMISSION != permissions) {
-                post.addParameter(PARAM_PERMISSIONS, Integer.toString(permissions));
+                jsonRequestBody.put(PARAM_PERMISSIONS, Integer.toString(permissions));
             }
 
             if (!TextUtils.isEmpty(note)) {
-                post.addParameter(PARAM_NOTE, note);
+                jsonRequestBody.put(PARAM_NOTE, note);
             }
 
-            post.addRequestHeader(OCS_API_HEADER, OCS_API_HEADER_VALUE);
+            // post method
+            post = new PostMethod(client.getBaseUri() + ShareUtils.SHARING_API_PATH, true, jsonRequestBody.get());
+            post.addRequestHeader(CONTENT_TYPE, FORM_URLENCODED);
 
-            status = client.executeMethod(post);
+            status = client.execute(post);
 
             if (isSuccess(status)) {
                 String response = post.getResponseBodyAsString();
 
-                ShareToRemoteOperationResultParser parser = new ShareToRemoteOperationResultParser(
-                        new ShareXMLParser()
-                );
+                ShareToRemoteOperationResultParser parser =
+                        new ShareToRemoteOperationResultParser(new ShareXMLParser());
                 parser.setOneOrMoreSharesRequired(true);
                 parser.setServerBaseUri(client.getBaseUri());
                 result = parser.parse(response);

--- a/library/src/main/java/com/owncloud/android/lib/resources/shares/GetShareRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/shares/GetShareRemoteOperation.java
@@ -25,18 +25,18 @@
 
 package com.owncloud.android.lib.resources.shares;
 
-import static com.owncloud.android.lib.resources.shares.ShareUtils.INCLUDE_TAGS;
-import static com.owncloud.android.lib.resources.shares.ShareUtils.SHARING_API_PATH;
-
-import com.owncloud.android.lib.common.OwnCloudClient;
+import com.nextcloud.common.NextcloudClient;
+import com.nextcloud.operations.GetMethod;
 import com.owncloud.android.lib.common.operations.RemoteOperation;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.lib.common.utils.Log_OC;
 
 import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.methods.GetMethod;
 
 import java.util.List;
+
+import static com.owncloud.android.lib.resources.shares.ShareUtils.INCLUDE_TAGS;
+import static com.owncloud.android.lib.resources.shares.ShareUtils.SHARING_API_PATH;
 
 /**
  * Get the data about a Share resource, known its remote ID.
@@ -55,20 +55,18 @@ public class GetShareRemoteOperation extends RemoteOperation<List<OCShare>> {
 
 
     @Override
-    protected RemoteOperationResult<List<OCShare>> run(OwnCloudClient client) {
+    public RemoteOperationResult<List<OCShare>> run(NextcloudClient client) {
         RemoteOperationResult<List<OCShare>> result;
         int status;
 
-        // Get Method
-        GetMethod get = null;
+        // get method
+        com.nextcloud.operations.GetMethod get = null;
 
-        // Get the response
         try {
-            get = new GetMethod(client.getBaseUri() + SHARING_API_PATH + "/" + remoteId);
+            get = new GetMethod(client.getBaseUri() + SHARING_API_PATH + "/" + remoteId, true);
             get.setQueryString(INCLUDE_TAGS);
-            get.addRequestHeader(OCS_API_HEADER, OCS_API_HEADER_VALUE);
 
-            status = client.executeMethod(get);
+            status = client.execute(get);
 
             if (isSuccess(status)) {
                 String response = get.getResponseBodyAsString();

--- a/library/src/main/java/com/owncloud/android/lib/resources/shares/GetShareesRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/shares/GetShareesRemoteOperation.java
@@ -29,17 +29,18 @@ package com.owncloud.android.lib.resources.shares;
 
 import android.net.Uri;
 
-import com.owncloud.android.lib.common.OwnCloudClient;
+import com.nextcloud.common.NextcloudClient;
+import com.nextcloud.operations.GetMethod;
 import com.owncloud.android.lib.common.operations.RemoteOperation;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.lib.common.utils.Log_OC;
 
 import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.methods.GetMethod;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Created by masensio on 08/10/2015.
@@ -62,7 +63,7 @@ import java.util.ArrayList;
  * Status codes:
  *    100 - successful
  */
-public class GetShareesRemoteOperation extends RemoteOperation {
+public class GetShareesRemoteOperation extends RemoteOperation<List<Object>> {
 
     private static final String TAG = GetShareesRemoteOperation.class.getSimpleName();
 
@@ -120,10 +121,10 @@ public class GetShareesRemoteOperation extends RemoteOperation {
     }
 
     @Override
-    protected RemoteOperationResult run(OwnCloudClient client) {
-        RemoteOperationResult result;
+    public RemoteOperationResult<List<Object>> run(NextcloudClient client) {
+        RemoteOperationResult<List<Object>> result;
         int status;
-        GetMethod get = null;
+        com.nextcloud.operations.GetMethod get = null;
 
         try{
             Uri requestUri = client.getBaseUri();
@@ -137,10 +138,9 @@ public class GetShareesRemoteOperation extends RemoteOperation {
             uriBuilder.appendQueryParameter(PARAM_LOOKUP, VALUE_FALSE);
 
             // Get Method
-            get = new GetMethod(uriBuilder.build().toString());
-            get.addRequestHeader(OCS_API_HEADER, OCS_API_HEADER_VALUE);
+            get = new GetMethod(uriBuilder.build().toString(), true);
 
-            status = client.executeMethod(get);
+            status = client.execute(get);
 
             if (isSuccess(status)) {
                 String response = get.getResponseBodyAsString();
@@ -213,25 +213,20 @@ public class GetShareesRemoteOperation extends RemoteOperation {
                 }
 
                 // Result
-                result = new RemoteOperationResult(true, get);
-                result.setData(data);
+                result = new RemoteOperationResult<>(true, get);
+                result.setResultData(data);
 
                 Log_OC.d(TAG, "*** Get Users or groups completed");
 
             } else {
-                result = new RemoteOperationResult(false, get);
+                result = new RemoteOperationResult<>(false, get);
                 String response = get.getResponseBodyAsString();
                 Log_OC.e(TAG, "Failed response while getting users/groups from the server");
-
-                if (response != null) {
-                    Log_OC.e(TAG, "*** status code: " + status + "; response message: " + response);
-                } else {
-                    Log_OC.e(TAG, "*** status code: " + status);
-                }
+                Log_OC.e(TAG, "*** status code: " + status + "; response message: " + response);
             }
 
         } catch (Exception e) {
-            result = new RemoteOperationResult(e);
+            result = new RemoteOperationResult<>(e);
             Log_OC.e(TAG, "Exception while getting users/groups", e);
 
         } finally {

--- a/library/src/main/java/com/owncloud/android/lib/resources/shares/GetSharesForFileRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/shares/GetSharesForFileRemoteOperation.java
@@ -26,21 +26,23 @@
 
 package com.owncloud.android.lib.resources.shares;
 
-import com.owncloud.android.lib.common.OwnCloudClient;
+import com.nextcloud.common.NextcloudClient;
+import com.nextcloud.operations.GetMethod;
 import com.owncloud.android.lib.common.operations.RemoteOperation;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.lib.common.utils.Log_OC;
 
 import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.NameValuePair;
-import org.apache.commons.httpclient.methods.GetMethod;
+
+import java.util.List;
+import java.util.Map;
 
 /**
  * Provide a list shares for a specific file.
  * The input is the full path of the desired file.
  * The output is a list of everyone who has the file shared with them.
  */
-public class GetSharesForFileRemoteOperation extends RemoteOperation {
+public class GetSharesForFileRemoteOperation extends RemoteOperation<List<OCShare>> {
 
     private static final String TAG = GetSharesForFileRemoteOperation.class.getSimpleName();
 
@@ -48,9 +50,9 @@ public class GetSharesForFileRemoteOperation extends RemoteOperation {
     private static final String PARAM_RESHARES = "reshares";
     private static final String PARAM_SUBFILES = "subfiles";
 
-    private String mRemoteFilePath;
-    private boolean mReshares;
-    private boolean mSubfiles;
+    private final String mRemoteFilePath;
+    private final boolean mReshares;
+    private final boolean mSubfiles;
 
     /**
      * Constructor
@@ -62,35 +64,31 @@ public class GetSharesForFileRemoteOperation extends RemoteOperation {
      * @param subfiles       If set to false (default), lists only the folder being shared
      *                       If set to true, all shared files within the folder are returned.
      */
-    public GetSharesForFileRemoteOperation(String remoteFilePath, boolean reshares,
-                                           boolean subfiles) {
+    public GetSharesForFileRemoteOperation(String remoteFilePath, boolean reshares, boolean subfiles) {
         mRemoteFilePath = remoteFilePath;
         mReshares = reshares;
         mSubfiles = subfiles;
     }
 
     @Override
-    protected RemoteOperationResult run(OwnCloudClient client) {
-        RemoteOperationResult result = null;
-        int status = -1;
+    public RemoteOperationResult<List<OCShare>> run(NextcloudClient client) {
+        RemoteOperationResult<List<OCShare>> result;
+        int status;
 
         GetMethod get = null;
 
         try {
-            // Get Method
-            get = new GetMethod(client.getBaseUri() + ShareUtils.SHARING_API_PATH);
+            // get method
+            get = new com.nextcloud.operations.GetMethod(client.getBaseUri() + ShareUtils.SHARING_API_PATH, true);
 
-            // Add Parameters to Get Method
-            get.setQueryString(new NameValuePair[]{
-                new NameValuePair(PARAM_PATH, mRemoteFilePath),
-                new NameValuePair(PARAM_RESHARES, String.valueOf(mReshares)),
-                    new NameValuePair(PARAM_SUBFILES, String.valueOf(mSubfiles)) //,
-                    //new NameValuePair("shared_with_me", "true")
-            });
+            // add parameters to get method
+            get.setQueryString(Map.of(
+                    PARAM_PATH, mRemoteFilePath,
+                    PARAM_RESHARES, String.valueOf(mReshares),
+                    PARAM_SUBFILES, String.valueOf(mSubfiles)
+                                     ));
 
-            get.addRequestHeader(OCS_API_HEADER, OCS_API_HEADER_VALUE);
-
-            status = client.executeMethod(get);
+            status = client.execute(get);
 
             if (isSuccess(status)) {
                 String response = get.getResponseBodyAsString();
@@ -103,15 +101,15 @@ public class GetSharesForFileRemoteOperation extends RemoteOperation {
                 result = parser.parse(response);
 
                 if (result.isSuccess()) {
-                    Log_OC.d(TAG, "Got " + result.getData().size() + " shares");
+                    Log_OC.d(TAG, "Got " + result.getResultData().size() + " shares");
                 }
 
             } else {
-                result = new RemoteOperationResult(false, get);
+                result = new RemoteOperationResult<>(false, get);
             }
 
         } catch (Exception e) {
-            result = new RemoteOperationResult(e);
+            result = new RemoteOperationResult<>(e);
             Log_OC.e(TAG, "Exception while getting shares", e);
 
         } finally {

--- a/library/src/main/java/com/owncloud/android/lib/resources/shares/GetSharesRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/shares/GetSharesRemoteOperation.java
@@ -26,17 +26,18 @@
 
 package com.owncloud.android.lib.resources.shares;
 
-import static com.owncloud.android.lib.resources.shares.ShareUtils.INCLUDE_TAGS;
-
-import com.owncloud.android.lib.common.OwnCloudClient;
+import com.nextcloud.common.NextcloudClient;
+import com.nextcloud.operations.GetMethod;
 import com.owncloud.android.lib.common.operations.RemoteOperation;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.lib.common.utils.Log_OC;
 
 import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.methods.GetMethod;
 
 import java.util.List;
+import java.util.Map;
+
+import static com.owncloud.android.lib.resources.shares.ShareUtils.INCLUDE_TAGS;
 
 /**
  * Get the data from the server about ALL the known shares owned by the requester.
@@ -44,7 +45,7 @@ import java.util.List;
 public class GetSharesRemoteOperation extends RemoteOperation<List<OCShare>> {
 
     private static final String TAG = GetSharesRemoteOperation.class.getSimpleName();
-    private boolean sharedWithMe = false;
+    private final boolean sharedWithMe;
 
     public GetSharesRemoteOperation() {
         this(false);
@@ -55,24 +56,23 @@ public class GetSharesRemoteOperation extends RemoteOperation<List<OCShare>> {
     }
 
     @Override
-    protected RemoteOperationResult<List<OCShare>> run(OwnCloudClient client) {
+    public RemoteOperationResult<List<OCShare>> run(NextcloudClient client) {
         RemoteOperationResult<List<OCShare>> result;
         int status;
 
         // Get Method
-        GetMethod get = null;
+        com.nextcloud.operations.GetMethod get = null;
 
         // Get the response
         try {
-            get = new GetMethod(client.getBaseUri() + ShareUtils.SHARING_API_PATH);
+            get = new GetMethod(client.getBaseUri() + ShareUtils.SHARING_API_PATH, true);
             get.setQueryString(INCLUDE_TAGS);
-            get.addRequestHeader(OCS_API_HEADER, OCS_API_HEADER_VALUE);
 
             if (sharedWithMe) {
-                get.setQueryString("shared_with_me=true");
+                get.setQueryString(Map.of("shared_with_me", "true"));
             }
 
-            status = client.executeMethod(get);
+            status = client.execute(get);
 
             if (isSuccess(status)) {
                 String response = get.getResponseBodyAsString();

--- a/library/src/main/java/com/owncloud/android/lib/resources/shares/RemoveShareRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/shares/RemoveShareRemoteOperation.java
@@ -26,23 +26,25 @@
 
 package com.owncloud.android.lib.resources.shares;
 
-import com.owncloud.android.lib.common.OwnCloudClient;
+import com.nextcloud.common.NextcloudClient;
+import com.nextcloud.operations.DeleteMethod;
 import com.owncloud.android.lib.common.operations.RemoteOperation;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.lib.common.utils.Log_OC;
 
 import org.apache.commons.httpclient.HttpStatus;
-import org.apache.jackrabbit.webdav.client.methods.DeleteMethod;
+
+import java.util.List;
 
 /**
  * Remove a share
  */
 
-public class RemoveShareRemoteOperation extends RemoteOperation {
+public class RemoveShareRemoteOperation extends RemoteOperation<List<OCShare>> {
 
     private static final String TAG = RemoveShareRemoteOperation.class.getSimpleName();
 
-    private long remoteShareId;
+    private final long remoteShareId;
 
     /**
      * Constructor
@@ -56,16 +58,14 @@ public class RemoveShareRemoteOperation extends RemoteOperation {
     }
 
     @Override
-    protected RemoteOperationResult run(OwnCloudClient client) {
-        RemoteOperationResult result;
-        DeleteMethod delete = null;
+    public RemoteOperationResult<List<OCShare>> run(NextcloudClient client) {
+        RemoteOperationResult<List<OCShare>> result;
+        com.nextcloud.operations.DeleteMethod delete = null;
 
         try {
-            delete = new DeleteMethod(client.getBaseUri() + ShareUtils.SHARING_API_PATH + "/" + remoteShareId);
+            delete = new DeleteMethod(client.getBaseUri() + ShareUtils.SHARING_API_PATH + "/" + remoteShareId, true);
 
-            delete.addRequestHeader(OCS_API_HEADER, OCS_API_HEADER_VALUE);
-
-            int status = client.executeMethod(delete);
+            int status = client.execute(delete);
 
             if (isSuccess(status)) {
                 String response = delete.getResponseBodyAsString();
@@ -79,10 +79,10 @@ public class RemoveShareRemoteOperation extends RemoteOperation {
                 Log_OC.d(TAG, "Unshare " + remoteShareId + ": " + result.getLogMessage());
 
             } else {
-                result = new RemoteOperationResult(false, delete);
+                result = new RemoteOperationResult<>(false, delete);
             }
         } catch (Exception e) {
-            result = new RemoteOperationResult(e);
+            result = new RemoteOperationResult<>(e);
             Log_OC.e(TAG, "Unshare Link Exception " + result.getLogMessage(), e);
 
         } finally {

--- a/library/src/main/java/com/owncloud/android/lib/resources/shares/ShareUtils.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/shares/ShareUtils.java
@@ -24,6 +24,8 @@
 
 package com.owncloud.android.lib.resources.shares;
 
+import java.util.Map;
+
 /**
  * Contains Constants for Share Operation
  *
@@ -36,7 +38,7 @@ public class ShareUtils {
     // OCS Route
     public static final String SHARING_API_PATH = "/ocs/v2.php/apps/files_sharing/api/v1/shares";
 
-    public static final String INCLUDE_TAGS = "include_tags=true";
+    public static final Map<String, String> INCLUDE_TAGS = Map.of("include_tags", "true");
 
     // String to build the link with the token of a share:
     public static final String SHARING_LINK_PATH_AFTER_VERSION_8 = "/index.php/s/";

--- a/library/src/main/java/com/owncloud/android/lib/resources/shares/UpdateShareRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/shares/UpdateShareRemoteOperation.java
@@ -28,14 +28,14 @@ package com.owncloud.android.lib.resources.shares;
 import android.net.Uri;
 import android.util.Pair;
 
-import com.owncloud.android.lib.common.OwnCloudClient;
+import com.nextcloud.common.JSONRequestBody;
+import com.nextcloud.common.NextcloudClient;
+import com.nextcloud.operations.PutMethod;
 import com.owncloud.android.lib.common.operations.RemoteOperation;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.lib.common.utils.Log_OC;
 
 import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.methods.PutMethod;
-import org.apache.commons.httpclient.methods.StringRequestEntity;
 
 import java.net.URLEncoder;
 import java.text.DateFormat;
@@ -51,7 +51,7 @@ import java.util.Locale;
  * 
  * Allow updating several parameters, triggering a request to the server per parameter.
  */
-public class UpdateShareRemoteOperation extends RemoteOperation {
+public class UpdateShareRemoteOperation extends RemoteOperation<List<OCShare>> {
 
     private static final String TAG = GetShareRemoteOperation.class.getSimpleName();
 
@@ -62,14 +62,12 @@ public class UpdateShareRemoteOperation extends RemoteOperation {
     private static final String PARAM_HIDE_DOWNLOAD = "hideDownload";
     private static final String PARAM_LABEL = "label";
     private static final String FORMAT_EXPIRATION_DATE = "yyyy-MM-dd";
-    private static final String ENTITY_CONTENT_TYPE = "application/x-www-form-urlencoded";
-    private static final String ENTITY_CHARSET = "UTF-8";
 
 
     /**
      * Identifier of the share to update
      */
-    private long remoteId;
+    private final long remoteId;
 
     /**
      * Password to set for the public link
@@ -157,7 +155,7 @@ public class UpdateShareRemoteOperation extends RemoteOperation {
     }
 
     @Override
-    protected RemoteOperationResult<List<OCShare>> run(OwnCloudClient client) {
+    public RemoteOperationResult<List<OCShare>> run(NextcloudClient client) {
         RemoteOperationResult<List<OCShare>> result = null;
         int status;
 
@@ -197,7 +195,7 @@ public class UpdateShareRemoteOperation extends RemoteOperation {
         }
 
         /// perform required PUT requests
-        PutMethod put = null;
+        com.nextcloud.operations.PutMethod put = null;
         String uriString;
 
         try {
@@ -211,15 +209,11 @@ public class UpdateShareRemoteOperation extends RemoteOperation {
                 if (put != null) {
                     put.releaseConnection();
                 }
-                put = new PutMethod(uriString);
-                put.addRequestHeader(OCS_API_HEADER, OCS_API_HEADER_VALUE);
-                put.setRequestEntity(new StringRequestEntity(
-                        parameter.first + "=" + parameter.second,
-                        ENTITY_CONTENT_TYPE,
-                        ENTITY_CHARSET
-                ));
+                JSONRequestBody jsonRequestBody = new JSONRequestBody(parameter.first, parameter.second);
 
-                status = client.executeMethod(put);
+                put = new PutMethod(uriString, true, jsonRequestBody.get());
+
+                status = client.execute(put);
 
                 if (status == HttpStatus.SC_OK || status == HttpStatus.SC_BAD_REQUEST) {
                     String response = put.getResponseBodyAsString();

--- a/library/src/main/java/com/owncloud/android/lib/resources/status/GetStatusRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/status/GetStatusRemoteOperation.java
@@ -28,21 +28,18 @@ import android.content.Context;
 import android.net.ConnectivityManager;
 import android.net.Uri;
 
-import com.owncloud.android.lib.common.OwnCloudClient;
-import com.owncloud.android.lib.common.OwnCloudClientManagerFactory;
+import com.nextcloud.common.NextcloudClient;
+import com.nextcloud.operations.GetMethod;
 import com.owncloud.android.lib.common.accounts.AccountUtils;
 import com.owncloud.android.lib.common.operations.RemoteOperation;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.lib.common.utils.Log_OC;
 
 import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.methods.GetMethod;
-import org.apache.commons.httpclient.params.HttpMethodParams;
-import org.apache.commons.httpclient.params.HttpParams;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.util.ArrayList;
+import kotlin.Pair;
 
 /**
  * Checks if the server is valid and if the server supports the Share API
@@ -50,13 +47,7 @@ import java.util.ArrayList;
  * @author David A. Velasco
  * @author masensio
  */
-public class GetStatusRemoteOperation extends RemoteOperation {
-
-    /**
-     * Maximum time to wait for a response from the server when the connection is being tested, in MILLISECONDs.
-     */
-    private static final int TRY_CONNECTION_TIMEOUT = 50000;
-
+public class GetStatusRemoteOperation extends RemoteOperation<Pair<OwnCloudVersion, Boolean>> {
     private static final String TAG = GetStatusRemoteOperation.class.getSimpleName();
 
     private static final String NODE_INSTALLED = "installed";
@@ -66,28 +57,24 @@ public class GetStatusRemoteOperation extends RemoteOperation {
     private static final String PROTOCOL_HTTP = "http://";
     private static final int UNTRUSTED_DOMAIN_ERROR_CODE = 15;
 
-    private RemoteOperationResult mLatestResult;
-    private Context mContext;
+    private RemoteOperationResult<Pair<OwnCloudVersion, Boolean>> mLatestResult;
+    private final Context mContext;
 
     public GetStatusRemoteOperation(Context context) {
         mContext = context;
     }
 
-    private boolean tryConnection(OwnCloudClient client) {
+    private boolean tryConnection(NextcloudClient client) {
         boolean retval = false;
-        GetMethod get = null;
-        String baseUrlSt = client.getBaseUri().toString();
+        com.nextcloud.operations.GetMethod get = null;
+        String baseUrlSt = String.valueOf(client.getBaseUri());
         try {
-            get = new GetMethod(baseUrlSt + AccountUtils.STATUS_PATH);
-
-            HttpParams params = HttpMethodParams.getDefaultParams();
-            params.setParameter(HttpMethodParams.USER_AGENT, OwnCloudClientManagerFactory.getUserAgent());
-            get.getParams().setDefaults(params);
+            get = new com.nextcloud.operations.GetMethod(baseUrlSt + AccountUtils.STATUS_PATH, false);
 
             client.setFollowRedirects(false);
             boolean isRedirectToNonSecureConnection = false;
-            int status = client.executeMethod(get, TRY_CONNECTION_TIMEOUT, TRY_CONNECTION_TIMEOUT);
-            mLatestResult = new RemoteOperationResult((status == HttpStatus.SC_OK), get);
+            int status = client.execute(get);
+            mLatestResult = new RemoteOperationResult<>((status == HttpStatus.SC_OK), get);
 
             String redirectedLocation = mLatestResult.getRedirectedLocation();
             while (redirectedLocation != null && redirectedLocation.length() > 0
@@ -98,9 +85,9 @@ public class GetStatusRemoteOperation extends RemoteOperation {
                                 redirectedLocation.startsWith(PROTOCOL_HTTP)
                 );
                 get.releaseConnection();
-                get = new GetMethod(redirectedLocation);
-                status = client.executeMethod(get, TRY_CONNECTION_TIMEOUT, TRY_CONNECTION_TIMEOUT);
-                mLatestResult = new RemoteOperationResult((status == HttpStatus.SC_OK), get);
+                get = new GetMethod(redirectedLocation, false);
+                status = client.execute(get);
+                mLatestResult = new RemoteOperationResult<>((status == HttpStatus.SC_OK), get);
                 redirectedLocation = mLatestResult.getRedirectedLocation();
             }
 
@@ -109,7 +96,7 @@ public class GetStatusRemoteOperation extends RemoteOperation {
             if (status == HttpStatus.SC_OK) {
                 JSONObject json = new JSONObject(response);
                 if (!json.getBoolean(NODE_INSTALLED)) {
-                    mLatestResult = new RemoteOperationResult(
+                    mLatestResult = new RemoteOperationResult<>(
                             RemoteOperationResult.ResultCode.INSTANCE_NOT_CONFIGURED);
                 } else {
                     boolean extendedSupport = false;
@@ -121,24 +108,22 @@ public class GetStatusRemoteOperation extends RemoteOperation {
                     OwnCloudVersion ocVersion = new OwnCloudVersion(version);
 
                     if (!ocVersion.isVersionValid()) {
-                        mLatestResult = new RemoteOperationResult(RemoteOperationResult.ResultCode.BAD_OC_VERSION);
+                        mLatestResult = new RemoteOperationResult<>(RemoteOperationResult.ResultCode.BAD_OC_VERSION);
                     } else {
                         // success
                         if (isRedirectToNonSecureConnection) {
-                            mLatestResult = new RemoteOperationResult(
+                            mLatestResult = new RemoteOperationResult<>(
                                     RemoteOperationResult.ResultCode.OK_REDIRECT_TO_NON_SECURE_CONNECTION);
                         } else {
-                            mLatestResult = new RemoteOperationResult(
+                            mLatestResult = new RemoteOperationResult<>(
                                     baseUrlSt.startsWith(PROTOCOL_HTTPS) ?
                                             RemoteOperationResult.ResultCode.OK_SSL :
                                             RemoteOperationResult.ResultCode.OK_NO_SSL
                             );
                         }
 
-                        ArrayList<Object> data = new ArrayList<>();
-                        data.add(ocVersion);
-                        data.add(extendedSupport);
-                        mLatestResult.setData(data);
+                        Pair<OwnCloudVersion, Boolean> data = new Pair<>(ocVersion, extendedSupport);
+                        mLatestResult.setResultData(data);
                         retval = true;
                     }
                 }
@@ -147,22 +132,22 @@ public class GetStatusRemoteOperation extends RemoteOperation {
                     JSONObject json = new JSONObject(response);
 
                     if (json.getInt("code") == UNTRUSTED_DOMAIN_ERROR_CODE) {
-                        mLatestResult = new RemoteOperationResult(RemoteOperationResult.ResultCode.UNTRUSTED_DOMAIN);
+                        mLatestResult = new RemoteOperationResult<>(RemoteOperationResult.ResultCode.UNTRUSTED_DOMAIN);
                     } else {
-                        mLatestResult = new RemoteOperationResult(false, status, get.getResponseHeaders());
+                        mLatestResult = new RemoteOperationResult<>(false, get);
                     }
                 } catch (JSONException e) {
-                    mLatestResult = new RemoteOperationResult(false, status, get.getResponseHeaders());
+                    mLatestResult = new RemoteOperationResult<>(false, get);
                 }
             } else {
-                mLatestResult = new RemoteOperationResult(false, status, get.getResponseHeaders());
+                mLatestResult = new RemoteOperationResult<>(false, get);
             }
 
         } catch (JSONException e) {
-            mLatestResult = new RemoteOperationResult(RemoteOperationResult.ResultCode.INSTANCE_NOT_CONFIGURED);
+            mLatestResult = new RemoteOperationResult<>(RemoteOperationResult.ResultCode.INSTANCE_NOT_CONFIGURED);
 
         } catch (Exception e) {
-            mLatestResult = new RemoteOperationResult(e);
+            mLatestResult = new RemoteOperationResult<>(e);
 
         } finally {
             if (get != null)
@@ -184,18 +169,16 @@ public class GetStatusRemoteOperation extends RemoteOperation {
     }
 
     private boolean isOnline() {
-        ConnectivityManager cm = (ConnectivityManager) mContext
-                .getSystemService(Context.CONNECTIVITY_SERVICE);
-        return cm != null && cm.getActiveNetworkInfo() != null
-                && cm.getActiveNetworkInfo().isConnectedOrConnecting();
+        ConnectivityManager cm = (ConnectivityManager) mContext.getSystemService(Context.CONNECTIVITY_SERVICE);
+        return cm != null && cm.getActiveNetworkInfo() != null && cm.getActiveNetworkInfo().isConnectedOrConnecting();
     }
 
     @Override
-    protected RemoteOperationResult run(OwnCloudClient client) {
+    public RemoteOperationResult<Pair<OwnCloudVersion, Boolean>> run(NextcloudClient client) {
         if (!isOnline()) {
-            return new RemoteOperationResult(RemoteOperationResult.ResultCode.NO_NETWORK_CONNECTION);
+            return new RemoteOperationResult<>(RemoteOperationResult.ResultCode.NO_NETWORK_CONNECTION);
         }
-        String baseUriStr = client.getBaseUri().toString();
+        String baseUriStr = String.valueOf(client.getBaseUri());
         if (baseUriStr.startsWith(PROTOCOL_HTTP) || baseUriStr.startsWith(PROTOCOL_HTTPS)) {
             tryConnection(client);
 

--- a/sample_client/build.gradle
+++ b/sample_client/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.2.1'
-        classpath 'com.github.spotbugs.snom:spotbugs-gradle-plugin:6.0.6'
+        classpath 'com.android.tools.build:gradle:8.2.0'
+        classpath 'com.github.spotbugs.snom:spotbugs-gradle-plugin:6.0.5'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.4"
         classpath "commons-httpclient:commons-httpclient:3.1@jar" // remove after entire switch to lib v2


### PR DESCRIPTION
This is one of a series of pull requests which aim to replace all instances of `OwnCloudClient` with `NextcloudClient`. The reason for this change is that the newer `NextcloudClient` uses OkHttp, replacing the outdated Jackrabbit methods.

Specifically, this pull request implements the following:
- changes related to sharing
- server status and info operations