### PR TITLE
Deprecate OwncloudClient - Comments

### DIFF
--- a/library/src/androidTest/java/com/owncloud/android/lib/resources/comments/CommentFileRemoteOperationIT.kt
+++ b/library/src/androidTest/java/com/owncloud/android/lib/resources/comments/CommentFileRemoteOperationIT.kt
@@ -29,7 +29,7 @@ class CommentFileRemoteOperationIT : AbstractIT() {
 
         assertTrue(
             CommentFileRemoteOperation("test", remoteFile.localId)
-                .execute(client)
+                .execute(nextcloudClient)
                 .isSuccess
         )
 

--- a/library/src/main/java/com/owncloud/android/lib/resources/comments/CommentFileRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/comments/CommentFileRemoteOperation.java
@@ -9,28 +9,22 @@ package com.owncloud.android.lib.resources.comments;
 
 import android.util.Log;
 
-import com.google.gson.GsonBuilder;
-import com.owncloud.android.lib.common.OwnCloudClient;
+import com.nextcloud.common.JSONRequestBody;
+import com.nextcloud.common.NextcloudClient;
+import com.nextcloud.operations.PostMethod;
 import com.owncloud.android.lib.common.operations.RemoteOperation;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 
 import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.methods.StringRequestEntity;
-import org.apache.commons.httpclient.methods.Utf8PostMethod;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Comment file
  */
-public class CommentFileRemoteOperation extends RemoteOperation {
+public class CommentFileRemoteOperation extends RemoteOperation<Void> {
 
     private static final String TAG = CommentFileRemoteOperation.class.getSimpleName();
-    private static final int POST_READ_TIMEOUT = 30000;
-    private static final int POST_CONNECTION_TIMEOUT = 5000;
-
     private static final String ACTOR_ID = "actorId";
     private static final String ACTOR_TYPE = "actorType";
     private static final String ACTOR_TYPE_VALUE = "users";
@@ -57,32 +51,27 @@ public class CommentFileRemoteOperation extends RemoteOperation {
      * @param client Client object to communicate with the remote ownCloud server.
      */
     @Override
-    protected RemoteOperationResult run(OwnCloudClient client) {
+    public RemoteOperationResult<Void> run(NextcloudClient client) {
 
-        Utf8PostMethod postMethod = null;
-        RemoteOperationResult result;
+        PostMethod postMethod = null;
+        RemoteOperationResult<Void> result;
         try {
+            // request body
+            JSONRequestBody jsonRequestBody = new JSONRequestBody(ACTOR_ID, client.getUserId());
+            jsonRequestBody.put(ACTOR_TYPE, ACTOR_TYPE_VALUE);
+            jsonRequestBody.put(VERB, VERB_VALUE);
+            jsonRequestBody.put(MESSAGE, message);
+
+            // post method
             String url = client.getCommentsUri(fileId);
-            postMethod = new Utf8PostMethod(url);
-            postMethod.addRequestHeader("Content-type", "application/json");
+            postMethod = new PostMethod(url, false, jsonRequestBody.get());
 
-            Map<String, String> values = new HashMap<>();
-            values.put(ACTOR_ID, client.getUserId());
-            values.put(ACTOR_TYPE, ACTOR_TYPE_VALUE);
-            values.put(VERB, VERB_VALUE);
-            values.put(MESSAGE, message);
+            int status = client.execute(postMethod);
 
-            String json = new GsonBuilder().create().toJson(values, Map.class);
+            result = new RemoteOperationResult<>(status == HttpStatus.SC_CREATED, postMethod);
 
-            postMethod.setRequestEntity(new StringRequestEntity(json));
-
-            int status = client.executeMethod(postMethod, POST_READ_TIMEOUT, POST_CONNECTION_TIMEOUT);
-
-            result = new RemoteOperationResult(isSuccess(status), postMethod);
-
-            client.exhaustResponse(postMethod.getResponseBodyAsStream());
         } catch (IOException e) {
-            result = new RemoteOperationResult(e);
+            result = new RemoteOperationResult<>(e);
             Log.e(TAG, "Post comment to file with id " + fileId + " failed: " + result.getLogMessage(), e);
         } finally {
             if (postMethod != null) {
@@ -91,9 +80,5 @@ public class CommentFileRemoteOperation extends RemoteOperation {
         }
 
         return result;
-    }
-
-    private boolean isSuccess(int status) {
-        return status == HttpStatus.SC_CREATED;
     }
 }


### PR DESCRIPTION
This is one of a series of pull requests which aim to replace all instances of `OwnCloudClient` with `NextcloudClient`. The reason for this change is that the newer `NextcloudClient` uses OkHttp, replacing the outdated Jackrabbit methods.

Specifically, this pull request implements the following:
- changes related to comments