### PR TITLE
Bugfix Delete Cached Nextcloud Client For Account Removal

### DIFF
--- a/library/src/main/java/com/owncloud/android/lib/common/OwnCloudClientManager.java
+++ b/library/src/main/java/com/owncloud/android/lib/common/OwnCloudClientManager.java
@@ -253,6 +253,7 @@ public class OwnCloudClientManager {
         String accountName = account.getName();
         if (accountName != null) {
             client = mClientsWithKnownUsername.remove(accountName);
+            clientsNewWithKnownUsername.remove(accountName);
             if (client != null) {
                 if (Log.isLoggable(TAG, Log.VERBOSE)) {
                     Log_OC.v(TAG, "Removed client for account " + accountName);


### PR DESCRIPTION
Not deleting cached Nextcloud client was causing authentication problem. [Details](https://github.com/nextcloud/android/issues/12653)