### PR TITLE
Inject Session Time Out To The Remote Operation Constructors

### DIFF
--- a/library/src/main/java/com/nextcloud/android/lib/resources/users/GenerateAppPasswordRemoteOperation.java
+++ b/library/src/main/java/com/nextcloud/android/lib/resources/users/GenerateAppPasswordRemoteOperation.java
@@ -36,7 +36,7 @@ public class GenerateAppPasswordRemoteOperation extends OCSRemoteOperation {
     private final SessionTimeOut sessionTimeOut;
 
     public GenerateAppPasswordRemoteOperation() {
-        this.sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
+        sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
     }
 
     public GenerateAppPasswordRemoteOperation(SessionTimeOut sessionTimeOut) {

--- a/library/src/main/java/com/nextcloud/android/lib/resources/users/GenerateAppPasswordRemoteOperation.java
+++ b/library/src/main/java/com/nextcloud/android/lib/resources/users/GenerateAppPasswordRemoteOperation.java
@@ -36,7 +36,7 @@ public class GenerateAppPasswordRemoteOperation extends OCSRemoteOperation {
     private final SessionTimeOut sessionTimeOut;
 
     public GenerateAppPasswordRemoteOperation() {
-        sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
+        this(SessionTimeOutKt.getDefaultSessionTimeOut());
     }
 
     public GenerateAppPasswordRemoteOperation(SessionTimeOut sessionTimeOut) {

--- a/library/src/main/java/com/nextcloud/android/lib/resources/users/GenerateAppPasswordRemoteOperation.java
+++ b/library/src/main/java/com/nextcloud/android/lib/resources/users/GenerateAppPasswordRemoteOperation.java
@@ -7,6 +7,9 @@
  */
 package com.nextcloud.android.lib.resources.users;
 
+
+import com.nextcloud.common.SessionTimeOut;
+import com.nextcloud.common.SessionTimeOutKt;
 import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
 import com.owncloud.android.lib.common.utils.Log_OC;
@@ -23,14 +26,22 @@ import org.json.JSONObject;
 
 public class GenerateAppPasswordRemoteOperation extends OCSRemoteOperation {
     private static final String TAG = GenerateAppPasswordRemoteOperation.class.getSimpleName();
-    private static final int SYNC_READ_TIMEOUT = 40000;
-    private static final int SYNC_CONNECTION_TIMEOUT = 5000;
     private static final String DIRECT_ENDPOINT = "/ocs/v2.php/core/getapppassword";
 
     // JSON node names
     private static final String NODE_OCS = "ocs";
     private static final String NODE_DATA = "data";
     private static final String NODE_APPPASSWORD = "apppassword";
+
+    private final SessionTimeOut sessionTimeOut;
+
+    public GenerateAppPasswordRemoteOperation() {
+        this.sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
+    }
+
+    public GenerateAppPasswordRemoteOperation(SessionTimeOut sessionTimeOut) {
+        this.sessionTimeOut = sessionTimeOut;
+    }
 
     protected RemoteOperationResult run(OwnCloudClient client) {
         RemoteOperationResult result;
@@ -42,7 +53,7 @@ public class GenerateAppPasswordRemoteOperation extends OCSRemoteOperation {
             // remote request
             getMethod.addRequestHeader(OCS_API_HEADER, OCS_API_HEADER_VALUE);
 
-            int status = client.executeMethod(getMethod, SYNC_READ_TIMEOUT, SYNC_CONNECTION_TIMEOUT);
+            int status = client.executeMethod(getMethod, sessionTimeOut.getReadTimeOut(), sessionTimeOut.getConnectionTimeOut());
 
             if (status == HttpStatus.SC_OK) {
                 String response = getMethod.getResponseBodyAsString();

--- a/library/src/main/java/com/nextcloud/android/lib/richWorkspace/RichWorkspaceDirectEditingRemoteOperation.java
+++ b/library/src/main/java/com/nextcloud/android/lib/richWorkspace/RichWorkspaceDirectEditingRemoteOperation.java
@@ -8,6 +8,8 @@
 package com.nextcloud.android.lib.richWorkspace;
 
 import com.google.gson.GsonBuilder;
+import com.nextcloud.common.SessionTimeOut;
+import com.nextcloud.common.SessionTimeOutKt;
 import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.common.operations.RemoteOperation;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
@@ -27,15 +29,20 @@ import java.util.Map;
 
 public class RichWorkspaceDirectEditingRemoteOperation extends RemoteOperation {
     private static final String TAG = RichWorkspaceDirectEditingRemoteOperation.class.getSimpleName();
-    private static final int SYNC_READ_TIMEOUT = 40000;
-    private static final int SYNC_CONNECTION_TIMEOUT = 5000;
     private static final String DIRECT_ENDPOINT = "/ocs/v2.php/apps/text/workspace/direct";
     private static final String PATH = "path";
 
+    private final SessionTimeOut sessionTimeOut;
     private String path;
 
     public RichWorkspaceDirectEditingRemoteOperation(String path) {
         this.path = path;
+        this.sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
+    }
+
+    public RichWorkspaceDirectEditingRemoteOperation(String path, SessionTimeOut sessionTimeOut) {
+        this.path = path;
+        this.sessionTimeOut = sessionTimeOut;
     }
 
     protected RemoteOperationResult run(OwnCloudClient client) {
@@ -54,7 +61,7 @@ public class RichWorkspaceDirectEditingRemoteOperation extends RemoteOperation {
 
             postMethod.setRequestEntity(new StringRequestEntity(json));
 
-            int status = client.executeMethod(postMethod, SYNC_READ_TIMEOUT, SYNC_CONNECTION_TIMEOUT);
+            int status = client.executeMethod(postMethod, sessionTimeOut.getReadTimeOut(), sessionTimeOut.getConnectionTimeOut());
 
             if (status == HttpStatus.SC_OK) {
                 String response = postMethod.getResponseBodyAsString();
@@ -63,14 +70,14 @@ public class RichWorkspaceDirectEditingRemoteOperation extends RemoteOperation {
                 JSONObject respJSON = new JSONObject(response);
                 String url = (String) respJSON.getJSONObject("ocs").getJSONObject("data").get("url");
 
-                result = new RemoteOperationResult(true, postMethod);
+                result = new RemoteOperationResult<>(true, postMethod);
                 result.setSingleData(url);
             } else {
-                result = new RemoteOperationResult(false, postMethod);
+                result = new RemoteOperationResult<>(false, postMethod);
                 client.exhaustResponse(postMethod.getResponseBodyAsStream());
             }
         } catch (Exception e) {
-            result = new RemoteOperationResult(e);
+            result = new RemoteOperationResult<>(e);
             Log_OC.e(TAG, "Get edit url for rich workspace failed: " + result.getLogMessage(),
                     result.getException());
         } finally {

--- a/library/src/main/java/com/nextcloud/android/lib/richWorkspace/RichWorkspaceDirectEditingRemoteOperation.java
+++ b/library/src/main/java/com/nextcloud/android/lib/richWorkspace/RichWorkspaceDirectEditingRemoteOperation.java
@@ -33,11 +33,11 @@ public class RichWorkspaceDirectEditingRemoteOperation extends RemoteOperation {
     private static final String PATH = "path";
 
     private final SessionTimeOut sessionTimeOut;
-    private String path;
+    private final String path;
 
     public RichWorkspaceDirectEditingRemoteOperation(String path) {
         this.path = path;
-        this.sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
+        sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
     }
 
     public RichWorkspaceDirectEditingRemoteOperation(String path, SessionTimeOut sessionTimeOut) {

--- a/library/src/main/java/com/nextcloud/android/lib/richWorkspace/RichWorkspaceDirectEditingRemoteOperation.java
+++ b/library/src/main/java/com/nextcloud/android/lib/richWorkspace/RichWorkspaceDirectEditingRemoteOperation.java
@@ -36,8 +36,7 @@ public class RichWorkspaceDirectEditingRemoteOperation extends RemoteOperation {
     private final String path;
 
     public RichWorkspaceDirectEditingRemoteOperation(String path) {
-        this.path = path;
-        sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
+        this(path, SessionTimeOutKt.getDefaultSessionTimeOut());
     }
 
     public RichWorkspaceDirectEditingRemoteOperation(String path, SessionTimeOut sessionTimeOut) {

--- a/library/src/main/java/com/nextcloud/common/SessionTimeOut.kt
+++ b/library/src/main/java/com/nextcloud/common/SessionTimeOut.kt
@@ -10,4 +10,4 @@ package com.nextcloud.common
 data class SessionTimeOut(val readTimeOut: Int, val connectionTimeOut: Int)
 
 @Suppress("Detekt.MagicNumber")
-val defaultSessionTimeOut = SessionTimeOut(40000, 5000)
+val defaultSessionTimeOut = SessionTimeOut(60000, 15000)

--- a/library/src/main/java/com/nextcloud/common/SessionTimeOut.kt
+++ b/library/src/main/java/com/nextcloud/common/SessionTimeOut.kt
@@ -1,0 +1,12 @@
+/*
+ * Nextcloud Android Library
+ *
+ * SPDX-FileCopyrightText: 2024 Alper Ozturk <alper.ozturk@nextcloud.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+package com.nextcloud.common
+
+data class SessionTimeOut(val readTimeOut: Int, val connectionTimeOut: Int)
+
+val defaultSessionTimeOut = SessionTimeOut(40000, 5000)

--- a/library/src/main/java/com/nextcloud/common/SessionTimeOut.kt
+++ b/library/src/main/java/com/nextcloud/common/SessionTimeOut.kt
@@ -9,4 +9,5 @@ package com.nextcloud.common
 
 data class SessionTimeOut(val readTimeOut: Int, val connectionTimeOut: Int)
 
+@Suppress("Detekt.MagicNumber")
 val defaultSessionTimeOut = SessionTimeOut(40000, 5000)

--- a/library/src/main/java/com/owncloud/android/lib/resources/e2ee/GetMetadataRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/e2ee/GetMetadataRemoteOperation.java
@@ -44,8 +44,7 @@ public class GetMetadataRemoteOperation extends RemoteOperation<MetadataResponse
      * Constructor
      */
     public GetMetadataRemoteOperation(long fileId) {
-        this.fileId = fileId;
-        sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
+        this(fileId, SessionTimeOutKt.getDefaultSessionTimeOut());
     }
 
     public GetMetadataRemoteOperation(long fileId, SessionTimeOut sessionTimeOut) {

--- a/library/src/main/java/com/owncloud/android/lib/resources/e2ee/GetMetadataRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/e2ee/GetMetadataRemoteOperation.java
@@ -45,7 +45,7 @@ public class GetMetadataRemoteOperation extends RemoteOperation<MetadataResponse
      */
     public GetMetadataRemoteOperation(long fileId) {
         this.fileId = fileId;
-        this.sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
+        sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
     }
 
     public GetMetadataRemoteOperation(long fileId, SessionTimeOut sessionTimeOut) {

--- a/library/src/main/java/com/owncloud/android/lib/resources/e2ee/GetMetadataRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/e2ee/GetMetadataRemoteOperation.java
@@ -7,6 +7,8 @@
  */
 package com.owncloud.android.lib.resources.e2ee;
 
+import com.nextcloud.common.SessionTimeOut;
+import com.nextcloud.common.SessionTimeOutKt;
 import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.common.operations.RemoteOperation;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
@@ -25,8 +27,6 @@ import org.json.JSONObject;
 public class GetMetadataRemoteOperation extends RemoteOperation<MetadataResponse> {
 
     private static final String TAG = GetMetadataRemoteOperation.class.getSimpleName();
-    private static final int SYNC_READ_TIMEOUT = 40000;
-    private static final int SYNC_CONNECTION_TIMEOUT = 5000;
     private static final String METADATA_V1_URL = "/ocs/v2.php/apps/end_to_end_encryption/api/v1/meta-data/";
     private static final String METADATA_V2_URL = "/ocs/v2.php/apps/end_to_end_encryption/api/v2/meta-data/";
 
@@ -38,11 +38,19 @@ public class GetMetadataRemoteOperation extends RemoteOperation<MetadataResponse
 
     private final long fileId;
 
+    private final SessionTimeOut sessionTimeOut;
+
     /**
      * Constructor
      */
     public GetMetadataRemoteOperation(long fileId) {
         this.fileId = fileId;
+        this.sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
+    }
+
+    public GetMetadataRemoteOperation(long fileId, SessionTimeOut sessionTimeOut) {
+        this.fileId = fileId;
+        this.sessionTimeOut = sessionTimeOut;
     }
 
     /**
@@ -58,14 +66,14 @@ public class GetMetadataRemoteOperation extends RemoteOperation<MetadataResponse
             getMethod = new GetMethod(client.getBaseUri() + METADATA_V2_URL + fileId + JSON_FORMAT);
             getMethod.addRequestHeader(OCS_API_HEADER, OCS_API_HEADER_VALUE);
 
-            int status = client.executeMethod(getMethod, SYNC_READ_TIMEOUT, SYNC_CONNECTION_TIMEOUT);
+            int status = client.executeMethod(getMethod, sessionTimeOut.getReadTimeOut(), sessionTimeOut.getConnectionTimeOut());
 
             if (status == HttpStatus.SC_NOT_FOUND || status == HttpStatus.SC_INTERNAL_SERVER_ERROR) {
                 // retry with v1
                 getMethod = new GetMethod(client.getBaseUri() + METADATA_V1_URL + fileId + JSON_FORMAT);
                 getMethod.addRequestHeader(OCS_API_HEADER, OCS_API_HEADER_VALUE);
 
-                status = client.executeMethod(getMethod, SYNC_READ_TIMEOUT, SYNC_CONNECTION_TIMEOUT);
+                status = client.executeMethod(getMethod,  sessionTimeOut.getReadTimeOut(), sessionTimeOut.getConnectionTimeOut());
             }
 
             if (status == HttpStatus.SC_OK) {
@@ -102,5 +110,4 @@ public class GetMetadataRemoteOperation extends RemoteOperation<MetadataResponse
         }
         return result;
     }
-
 }

--- a/library/src/main/java/com/owncloud/android/lib/resources/e2ee/LockFileRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/e2ee/LockFileRemoteOperation.java
@@ -30,7 +30,9 @@ public class LockFileRemoteOperation extends RemoteOperation<String> {
     private static final String COUNTER_HEADER = "X-NC-E2EE-COUNTER";
 
     private final long localId;
-    private long counter = -1;
+    private final long counter;
+
+    private static final long defaultCounter = -1;
 
     // JSON node names
     private static final String NODE_OCS = "ocs";
@@ -42,24 +44,20 @@ public class LockFileRemoteOperation extends RemoteOperation<String> {
      * Constructor
      */
     public LockFileRemoteOperation(long localId, long counter) {
-        this.localId = localId;
-        this.counter = counter;
-        sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
+        this(localId, counter, SessionTimeOutKt.getDefaultSessionTimeOut());
     }
 
     public LockFileRemoteOperation(long localId) {
-        this.localId = localId;
-        sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
+        this(localId, SessionTimeOutKt.getDefaultSessionTimeOut());
+    }
+
+    public LockFileRemoteOperation(long localId, SessionTimeOut sessionTimeOut) {
+        this(localId, defaultCounter, sessionTimeOut);
     }
 
     public LockFileRemoteOperation(long localId, long counter, SessionTimeOut sessionTimeOut) {
         this.localId = localId;
         this.counter = counter;
-        this.sessionTimeOut = sessionTimeOut;
-    }
-
-    public LockFileRemoteOperation(long localId, SessionTimeOut sessionTimeOut) {
-        this.localId = localId;
         this.sessionTimeOut = sessionTimeOut;
     }
 

--- a/library/src/main/java/com/owncloud/android/lib/resources/e2ee/LockFileRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/e2ee/LockFileRemoteOperation.java
@@ -44,12 +44,12 @@ public class LockFileRemoteOperation extends RemoteOperation<String> {
     public LockFileRemoteOperation(long localId, long counter) {
         this.localId = localId;
         this.counter = counter;
-        this.sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
+        sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
     }
 
     public LockFileRemoteOperation(long localId) {
         this.localId = localId;
-        this.sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
+        sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
     }
 
     public LockFileRemoteOperation(long localId, long counter, SessionTimeOut sessionTimeOut) {

--- a/library/src/main/java/com/owncloud/android/lib/resources/e2ee/LockFileRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/e2ee/LockFileRemoteOperation.java
@@ -7,6 +7,8 @@
  */
 package com.owncloud.android.lib.resources.e2ee;
 
+import com.nextcloud.common.SessionTimeOut;
+import com.nextcloud.common.SessionTimeOutKt;
 import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.common.operations.RemoteOperation;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
@@ -23,8 +25,6 @@ import org.json.JSONObject;
 public class LockFileRemoteOperation extends RemoteOperation<String> {
 
     private static final String TAG = LockFileRemoteOperation.class.getSimpleName();
-    private static final int SYNC_READ_TIMEOUT = 40000;
-    private static final int SYNC_CONNECTION_TIMEOUT = 5000;
     private static final String LOCK_FILE_URL = "/ocs/v2.php/apps/end_to_end_encryption/api/v1/lock/";
 
     private static final String COUNTER_HEADER = "X-NC-E2EE-COUNTER";
@@ -36,16 +36,31 @@ public class LockFileRemoteOperation extends RemoteOperation<String> {
     private static final String NODE_OCS = "ocs";
     private static final String NODE_DATA = "data";
 
+    private final SessionTimeOut sessionTimeOut;
+
     /**
      * Constructor
      */
     public LockFileRemoteOperation(long localId, long counter) {
         this.localId = localId;
         this.counter = counter;
+        this.sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
     }
 
     public LockFileRemoteOperation(long localId) {
         this.localId = localId;
+        this.sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
+    }
+
+    public LockFileRemoteOperation(long localId, long counter, SessionTimeOut sessionTimeOut) {
+        this.localId = localId;
+        this.counter = counter;
+        this.sessionTimeOut = sessionTimeOut;
+    }
+
+    public LockFileRemoteOperation(long localId, SessionTimeOut sessionTimeOut) {
+        this.localId = localId;
+        this.sessionTimeOut = sessionTimeOut;
     }
 
     /**
@@ -67,7 +82,7 @@ public class LockFileRemoteOperation extends RemoteOperation<String> {
                 postMethod.addRequestHeader(COUNTER_HEADER, String.valueOf(counter));
             }
 
-            int status = client.executeMethod(postMethod, SYNC_READ_TIMEOUT, SYNC_CONNECTION_TIMEOUT);
+            int status = client.executeMethod(postMethod, sessionTimeOut.getReadTimeOut(), sessionTimeOut.getConnectionTimeOut());
 
             if (status == HttpStatus.SC_OK) {
                 String response = postMethod.getResponseBodyAsString();

--- a/library/src/main/java/com/owncloud/android/lib/resources/e2ee/StoreMetadataRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/e2ee/StoreMetadataRemoteOperation.java
@@ -7,6 +7,8 @@
  */
 package com.owncloud.android.lib.resources.e2ee;
 
+import com.nextcloud.common.SessionTimeOut;
+import com.nextcloud.common.SessionTimeOutKt;
 import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.common.operations.RemoteOperation;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
@@ -26,8 +28,6 @@ import java.util.ArrayList;
 public class StoreMetadataRemoteOperation extends RemoteOperation {
 
     private static final String TAG = StoreMetadataRemoteOperation.class.getSimpleName();
-    private static final int SYNC_READ_TIMEOUT = 40000;
-    private static final int SYNC_CONNECTION_TIMEOUT = 5000;
     private static final String METADATA_URL = "/ocs/v2.php/apps/end_to_end_encryption/api/v1/meta-data/";
     private static final String METADATA = "metaData";
 
@@ -39,12 +39,21 @@ public class StoreMetadataRemoteOperation extends RemoteOperation {
     private final long fileId;
     private final String encryptedMetadataJson;
 
+    private final SessionTimeOut sessionTimeOut;
+
     /**
      * Constructor
      */
     public StoreMetadataRemoteOperation(long fileId, String encryptedMetadataJson) {
         this.fileId = fileId;
         this.encryptedMetadataJson = encryptedMetadataJson;
+        this.sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
+    }
+
+    public StoreMetadataRemoteOperation(long fileId, String encryptedMetadataJson, SessionTimeOut sessionTimeOut) {
+        this.fileId = fileId;
+        this.encryptedMetadataJson = encryptedMetadataJson;
+        this.sessionTimeOut = sessionTimeOut;
     }
 
     /**
@@ -61,7 +70,7 @@ public class StoreMetadataRemoteOperation extends RemoteOperation {
             postMethod.addRequestHeader(OCS_API_HEADER, OCS_API_HEADER_VALUE);
             postMethod.setParameter(METADATA, encryptedMetadataJson);
 
-            int status = client.executeMethod(postMethod, SYNC_READ_TIMEOUT, SYNC_CONNECTION_TIMEOUT);
+            int status = client.executeMethod(postMethod, sessionTimeOut.getReadTimeOut(), sessionTimeOut.getConnectionTimeOut());
 
             if (status == HttpStatus.SC_OK) {
                 String response = postMethod.getResponseBodyAsString();
@@ -71,16 +80,16 @@ public class StoreMetadataRemoteOperation extends RemoteOperation {
                 String metadata = (String) respJSON.getJSONObject(NODE_OCS).getJSONObject(NODE_DATA)
                         .get(NODE_META_DATA);
 
-                result = new RemoteOperationResult(true, postMethod);
+                result = new RemoteOperationResult<>(true, postMethod);
                 ArrayList<Object> keys = new ArrayList<>();
                 keys.add(metadata);
                 result.setData(keys);
             } else {
-                result = new RemoteOperationResult(false, postMethod);
+                result = new RemoteOperationResult<>(false, postMethod);
                 client.exhaustResponse(postMethod.getResponseBodyAsStream());
             }
         } catch (Exception e) {
-            result = new RemoteOperationResult(e);
+            result = new RemoteOperationResult<>(e);
             Log_OC.e(TAG, "Storing of metadata for folder " + fileId + " failed: " + result.getLogMessage(),
                      result.getException());
         } finally {

--- a/library/src/main/java/com/owncloud/android/lib/resources/e2ee/StoreMetadataRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/e2ee/StoreMetadataRemoteOperation.java
@@ -47,7 +47,7 @@ public class StoreMetadataRemoteOperation extends RemoteOperation {
     public StoreMetadataRemoteOperation(long fileId, String encryptedMetadataJson) {
         this.fileId = fileId;
         this.encryptedMetadataJson = encryptedMetadataJson;
-        this.sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
+        sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
     }
 
     public StoreMetadataRemoteOperation(long fileId, String encryptedMetadataJson, SessionTimeOut sessionTimeOut) {

--- a/library/src/main/java/com/owncloud/android/lib/resources/e2ee/StoreMetadataRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/e2ee/StoreMetadataRemoteOperation.java
@@ -45,9 +45,7 @@ public class StoreMetadataRemoteOperation extends RemoteOperation {
      * Constructor
      */
     public StoreMetadataRemoteOperation(long fileId, String encryptedMetadataJson) {
-        this.fileId = fileId;
-        this.encryptedMetadataJson = encryptedMetadataJson;
-        sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
+        this(fileId, encryptedMetadataJson, SessionTimeOutKt.getDefaultSessionTimeOut());
     }
 
     public StoreMetadataRemoteOperation(long fileId, String encryptedMetadataJson, SessionTimeOut sessionTimeOut) {

--- a/library/src/main/java/com/owncloud/android/lib/resources/e2ee/StoreMetadataV2RemoteOperation.kt
+++ b/library/src/main/java/com/owncloud/android/lib/resources/e2ee/StoreMetadataV2RemoteOperation.kt
@@ -26,7 +26,7 @@ class StoreMetadataV2RemoteOperation @JvmOverloads constructor(
     private val encryptedMetadataJson: String,
     private val token: String,
     private val signature: String,
-    var sessionTimeOut: SessionTimeOut = defaultSessionTimeOut
+    private val sessionTimeOut: SessionTimeOut = defaultSessionTimeOut
 ) : RemoteOperation<String>() {
 
     /**

--- a/library/src/main/java/com/owncloud/android/lib/resources/e2ee/StoreMetadataV2RemoteOperation.kt
+++ b/library/src/main/java/com/owncloud/android/lib/resources/e2ee/StoreMetadataV2RemoteOperation.kt
@@ -21,23 +21,13 @@ import org.json.JSONObject
 /**
  * Remote operation to store the folder metadata
  */
-class StoreMetadataV2RemoteOperation(
+class StoreMetadataV2RemoteOperation @JvmOverloads constructor(
     private val remoteId: String,
     private val encryptedMetadataJson: String,
     private val token: String,
-    private val signature: String
+    private val signature: String,
+    var sessionTimeOut: SessionTimeOut = defaultSessionTimeOut
 ) : RemoteOperation<String>() {
-    private var sessionTimeOut: SessionTimeOut = defaultSessionTimeOut
-
-    constructor(
-        remoteId: String,
-        encryptedMetadataJson: String,
-        token: String,
-        signature: String,
-        sessionTimeOut: SessionTimeOut
-    ) : this(remoteId, encryptedMetadataJson, token, signature) {
-        this.sessionTimeOut = sessionTimeOut
-    }
 
     /**
      * @param client Client object

--- a/library/src/main/java/com/owncloud/android/lib/resources/e2ee/StoreMetadataV2RemoteOperation.kt
+++ b/library/src/main/java/com/owncloud/android/lib/resources/e2ee/StoreMetadataV2RemoteOperation.kt
@@ -21,73 +21,76 @@ import org.json.JSONObject
 /**
  * Remote operation to store the folder metadata
  */
-class StoreMetadataV2RemoteOperation @JvmOverloads constructor(
-    private val remoteId: String,
-    private val encryptedMetadataJson: String,
-    private val token: String,
-    private val signature: String,
-    private val sessionTimeOut: SessionTimeOut = defaultSessionTimeOut
-) : RemoteOperation<String>() {
+class StoreMetadataV2RemoteOperation
+    @JvmOverloads
+    constructor(
+        private val remoteId: String,
+        private val encryptedMetadataJson: String,
+        private val token: String,
+        private val signature: String,
+        private val sessionTimeOut: SessionTimeOut = defaultSessionTimeOut
+    ) : RemoteOperation<String>() {
+        /**
+         * @param client Client object
+         */
+        @Deprecated("Deprecated in Java")
+        @Suppress("Detekt.TooGenericExceptionCaught")
+        override fun run(client: OwnCloudClient): RemoteOperationResult<String> {
+            var postMethod: Utf8PostMethod? = null
+            var result: RemoteOperationResult<String>
+            try {
+                // remote request
+                postMethod = Utf8PostMethod(client.baseUri.toString() + METADATA_URL + remoteId + JSON_FORMAT)
+                postMethod.addRequestHeader(OCS_API_HEADER, OCS_API_HEADER_VALUE)
+                postMethod.addRequestHeader(E2E_TOKEN, token)
+                postMethod.addRequestHeader(HEADER_SIGNATURE, signature)
+                postMethod.setParameter(METADATA, encryptedMetadataJson)
+                val status =
+                    client
+                        .executeMethod(postMethod, sessionTimeOut.readTimeOut, sessionTimeOut.connectionTimeOut)
+                if (status == HttpStatus.SC_OK) {
+                    val response = postMethod.responseBodyAsString
 
-    /**
-     * @param client Client object
-     */
-    @Deprecated("Deprecated in Java")
-    @Suppress("Detekt.TooGenericExceptionCaught")
-    override fun run(client: OwnCloudClient): RemoteOperationResult<String> {
-        var postMethod: Utf8PostMethod? = null
-        var result: RemoteOperationResult<String>
-        try {
-            // remote request
-            postMethod = Utf8PostMethod(client.baseUri.toString() + METADATA_URL + remoteId + JSON_FORMAT)
-            postMethod.addRequestHeader(OCS_API_HEADER, OCS_API_HEADER_VALUE)
-            postMethod.addRequestHeader(E2E_TOKEN, token)
-            postMethod.addRequestHeader(HEADER_SIGNATURE, signature)
-            postMethod.setParameter(METADATA, encryptedMetadataJson)
-            val status = client.executeMethod(postMethod, sessionTimeOut.readTimeOut, sessionTimeOut.connectionTimeOut)
-            if (status == HttpStatus.SC_OK) {
-                val response = postMethod.responseBodyAsString
-
-                // Parse the response
-                val respJSON = JSONObject(response)
-                val metadata =
-                    respJSON
-                        .getJSONObject(NODE_OCS)
-                        .getJSONObject(NODE_DATA)
-                        .getString(NODE_META_DATA)
-                result = RemoteOperationResult(true, postMethod)
-                result.setResultData(metadata)
-            } else {
-                result = RemoteOperationResult(false, postMethod)
-                Log.e(
+                    // Parse the response
+                    val respJSON = JSONObject(response)
+                    val metadata =
+                        respJSON
+                            .getJSONObject(NODE_OCS)
+                            .getJSONObject(NODE_DATA)
+                            .getString(NODE_META_DATA)
+                    result = RemoteOperationResult(true, postMethod)
+                    result.setResultData(metadata)
+                } else {
+                    result = RemoteOperationResult(false, postMethod)
+                    Log.e(
+                        TAG,
+                        "Storing of metadata for folder " + remoteId + " failed: " + postMethod.responseBodyAsString,
+                        result.exception
+                    )
+                    client.exhaustResponse(postMethod.responseBodyAsStream)
+                }
+            } catch (e: Exception) {
+                result = RemoteOperationResult(e)
+                Log_OC.e(
                     TAG,
-                    "Storing of metadata for folder " + remoteId + " failed: " + postMethod.responseBodyAsString,
+                    "Storing of metadata for folder " + remoteId + " failed: " + result.logMessage,
                     result.exception
                 )
-                client.exhaustResponse(postMethod.responseBodyAsStream)
+            } finally {
+                postMethod?.releaseConnection()
             }
-        } catch (e: Exception) {
-            result = RemoteOperationResult(e)
-            Log_OC.e(
-                TAG,
-                "Storing of metadata for folder " + remoteId + " failed: " + result.logMessage,
-                result.exception
-            )
-        } finally {
-            postMethod?.releaseConnection()
+            return result
         }
-        return result
-    }
 
-    companion object {
-        private val TAG = StoreMetadataV2RemoteOperation::class.java.simpleName
-        private const val METADATA_URL = "/ocs/v2.php/apps/end_to_end_encryption/api/v2/meta-data/"
-        private const val METADATA = "metaData"
-        private const val HEADER_SIGNATURE = "X-NC-E2EE-SIGNATURE"
+        companion object {
+            private val TAG = StoreMetadataV2RemoteOperation::class.java.simpleName
+            private const val METADATA_URL = "/ocs/v2.php/apps/end_to_end_encryption/api/v2/meta-data/"
+            private const val METADATA = "metaData"
+            private const val HEADER_SIGNATURE = "X-NC-E2EE-SIGNATURE"
 
-        // JSON node names
-        private const val NODE_OCS = "ocs"
-        private const val NODE_DATA = "data"
-        private const val NODE_META_DATA = "meta-data"
+            // JSON node names
+            private const val NODE_OCS = "ocs"
+            private const val NODE_DATA = "data"
+            private const val NODE_META_DATA = "meta-data"
+        }
     }
-}

--- a/library/src/main/java/com/owncloud/android/lib/resources/e2ee/StoreMetadataV2RemoteOperation.kt
+++ b/library/src/main/java/com/owncloud/android/lib/resources/e2ee/StoreMetadataV2RemoteOperation.kt
@@ -25,9 +25,21 @@ class StoreMetadataV2RemoteOperation(
     private val remoteId: String,
     private val encryptedMetadataJson: String,
     private val token: String,
-    private val signature: String,
-    private val sessionTimeOut: SessionTimeOut = defaultSessionTimeOut
+    private val signature: String
 ) : RemoteOperation<String>() {
+
+    private var sessionTimeOut: SessionTimeOut = defaultSessionTimeOut
+
+    constructor(
+        remoteId: String,
+        encryptedMetadataJson: String,
+        token: String,
+        signature: String,
+        sessionTimeOut: SessionTimeOut
+    ): this(remoteId, encryptedMetadataJson, token, signature) {
+        this.sessionTimeOut = sessionTimeOut
+    }
+
     /**
      * @param client Client object
      */

--- a/library/src/main/java/com/owncloud/android/lib/resources/e2ee/StoreMetadataV2RemoteOperation.kt
+++ b/library/src/main/java/com/owncloud/android/lib/resources/e2ee/StoreMetadataV2RemoteOperation.kt
@@ -8,6 +8,8 @@
 package com.owncloud.android.lib.resources.e2ee
 
 import android.util.Log
+import com.nextcloud.common.SessionTimeOut
+import com.nextcloud.common.defaultSessionTimeOut
 import com.owncloud.android.lib.common.OwnCloudClient
 import com.owncloud.android.lib.common.operations.RemoteOperation
 import com.owncloud.android.lib.common.operations.RemoteOperationResult
@@ -23,7 +25,8 @@ class StoreMetadataV2RemoteOperation(
     private val remoteId: String,
     private val encryptedMetadataJson: String,
     private val token: String,
-    private val signature: String
+    private val signature: String,
+    private val sessionTimeOut: SessionTimeOut = defaultSessionTimeOut
 ) : RemoteOperation<String>() {
     /**
      * @param client Client object
@@ -40,7 +43,7 @@ class StoreMetadataV2RemoteOperation(
             postMethod.addRequestHeader(E2E_TOKEN, token)
             postMethod.addRequestHeader(HEADER_SIGNATURE, signature)
             postMethod.setParameter(METADATA, encryptedMetadataJson)
-            val status = client.executeMethod(postMethod, SYNC_READ_TIMEOUT, SYNC_CONNECTION_TIMEOUT)
+            val status = client.executeMethod(postMethod, sessionTimeOut.readTimeOut, sessionTimeOut.connectionTimeOut)
             if (status == HttpStatus.SC_OK) {
                 val response = postMethod.responseBodyAsString
 
@@ -77,8 +80,6 @@ class StoreMetadataV2RemoteOperation(
 
     companion object {
         private val TAG = StoreMetadataV2RemoteOperation::class.java.simpleName
-        private const val SYNC_READ_TIMEOUT = 40000
-        private const val SYNC_CONNECTION_TIMEOUT = 5000
         private const val METADATA_URL = "/ocs/v2.php/apps/end_to_end_encryption/api/v2/meta-data/"
         private const val METADATA = "metaData"
         private const val HEADER_SIGNATURE = "X-NC-E2EE-SIGNATURE"

--- a/library/src/main/java/com/owncloud/android/lib/resources/e2ee/StoreMetadataV2RemoteOperation.kt
+++ b/library/src/main/java/com/owncloud/android/lib/resources/e2ee/StoreMetadataV2RemoteOperation.kt
@@ -27,7 +27,6 @@ class StoreMetadataV2RemoteOperation(
     private val token: String,
     private val signature: String
 ) : RemoteOperation<String>() {
-
     private var sessionTimeOut: SessionTimeOut = defaultSessionTimeOut
 
     constructor(
@@ -36,7 +35,7 @@ class StoreMetadataV2RemoteOperation(
         token: String,
         signature: String,
         sessionTimeOut: SessionTimeOut
-    ): this(remoteId, encryptedMetadataJson, token, signature) {
+    ) : this(remoteId, encryptedMetadataJson, token, signature) {
         this.sessionTimeOut = sessionTimeOut
     }
 

--- a/library/src/main/java/com/owncloud/android/lib/resources/e2ee/ToggleEncryptionRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/e2ee/ToggleEncryptionRemoteOperation.java
@@ -7,6 +7,8 @@
  */
 package com.owncloud.android.lib.resources.e2ee;
 
+import com.nextcloud.common.SessionTimeOut;
+import com.nextcloud.common.SessionTimeOutKt;
 import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.common.operations.RemoteOperation;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
@@ -26,13 +28,13 @@ import org.apache.commons.httpclient.methods.PutMethod;
 public class ToggleEncryptionRemoteOperation extends RemoteOperation<Void> {
 
     private static final String TAG = ToggleEncryptionRemoteOperation.class.getSimpleName();
-    private static final int SYNC_READ_TIMEOUT = 40000;
-    private static final int SYNC_CONNECTION_TIMEOUT = 5000;
     private static final String ENCRYPTED_URL = "/ocs/v2.php/apps/end_to_end_encryption/api/v1/encrypted/";
 
     private final long localId;
     private final String remotePath;
     private final boolean encryption;
+
+    private final SessionTimeOut sessionTimeOut;
 
     /**
      * Constructor
@@ -41,6 +43,14 @@ public class ToggleEncryptionRemoteOperation extends RemoteOperation<Void> {
         this.localId = localId;
         this.remotePath = remotePath;
         this.encryption = encryption;
+        this.sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
+    }
+
+    public ToggleEncryptionRemoteOperation(long localId, String remotePath, boolean encryption, SessionTimeOut sessionTimeOut) {
+        this.localId = localId;
+        this.remotePath = remotePath;
+        this.encryption = encryption;
+        this.sessionTimeOut = sessionTimeOut;
     }
 
     /**
@@ -72,7 +82,7 @@ public class ToggleEncryptionRemoteOperation extends RemoteOperation<Void> {
             method.addRequestHeader(OCS_API_HEADER, OCS_API_HEADER_VALUE);
             method.addRequestHeader(CONTENT_TYPE, FORM_URLENCODED);
 
-            int status = client.executeMethod(method, SYNC_READ_TIMEOUT, SYNC_CONNECTION_TIMEOUT);
+            int status = client.executeMethod(method, sessionTimeOut.getReadTimeOut(), sessionTimeOut.getConnectionTimeOut());
 
             if (status == HttpStatus.SC_OK) {
                 result = new RemoteOperationResult<>(true, method);

--- a/library/src/main/java/com/owncloud/android/lib/resources/e2ee/ToggleEncryptionRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/e2ee/ToggleEncryptionRemoteOperation.java
@@ -43,7 +43,7 @@ public class ToggleEncryptionRemoteOperation extends RemoteOperation<Void> {
         this.localId = localId;
         this.remotePath = remotePath;
         this.encryption = encryption;
-        this.sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
+        sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
     }
 
     public ToggleEncryptionRemoteOperation(long localId, String remotePath, boolean encryption, SessionTimeOut sessionTimeOut) {

--- a/library/src/main/java/com/owncloud/android/lib/resources/e2ee/ToggleEncryptionRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/e2ee/ToggleEncryptionRemoteOperation.java
@@ -40,10 +40,7 @@ public class ToggleEncryptionRemoteOperation extends RemoteOperation<Void> {
      * Constructor
      */
     public ToggleEncryptionRemoteOperation(long localId, String remotePath, boolean encryption) {
-        this.localId = localId;
-        this.remotePath = remotePath;
-        this.encryption = encryption;
-        sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
+        this(localId, remotePath, encryption, SessionTimeOutKt.getDefaultSessionTimeOut());
     }
 
     public ToggleEncryptionRemoteOperation(long localId, String remotePath, boolean encryption, SessionTimeOut sessionTimeOut) {

--- a/library/src/main/java/com/owncloud/android/lib/resources/e2ee/UnlockFileRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/e2ee/UnlockFileRemoteOperation.java
@@ -35,9 +35,7 @@ public class UnlockFileRemoteOperation extends RemoteOperation<Void> {
      * Constructor
      */
     public UnlockFileRemoteOperation(long localId, String token) {
-        this.localId = localId;
-        this.token = token;
-        sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
+        this(localId, token, SessionTimeOutKt.getDefaultSessionTimeOut());
     }
 
     public UnlockFileRemoteOperation(long localId, String token, SessionTimeOut sessionTimeOut) {

--- a/library/src/main/java/com/owncloud/android/lib/resources/e2ee/UnlockFileRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/e2ee/UnlockFileRemoteOperation.java
@@ -37,7 +37,7 @@ public class UnlockFileRemoteOperation extends RemoteOperation<Void> {
     public UnlockFileRemoteOperation(long localId, String token) {
         this.localId = localId;
         this.token = token;
-        this.sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
+        sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
     }
 
     public UnlockFileRemoteOperation(long localId, String token, SessionTimeOut sessionTimeOut) {

--- a/library/src/main/java/com/owncloud/android/lib/resources/e2ee/UnlockFileRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/e2ee/UnlockFileRemoteOperation.java
@@ -7,6 +7,8 @@
  */
 package com.owncloud.android.lib.resources.e2ee;
 
+import com.nextcloud.common.SessionTimeOut;
+import com.nextcloud.common.SessionTimeOutKt;
 import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.common.operations.RemoteOperation;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
@@ -22,12 +24,12 @@ import org.apache.commons.httpclient.methods.DeleteMethod;
 public class UnlockFileRemoteOperation extends RemoteOperation<Void> {
 
     private static final String TAG = UnlockFileRemoteOperation.class.getSimpleName();
-    private static final int SYNC_READ_TIMEOUT = 40000;
-    private static final int SYNC_CONNECTION_TIMEOUT = 5000;
     private static final String LOCK_FILE_URL = "/ocs/v2.php/apps/end_to_end_encryption/api/v2/lock/";
 
     private final long localId;
     private final String token;
+
+    private final SessionTimeOut sessionTimeOut;
 
     /**
      * Constructor
@@ -35,6 +37,13 @@ public class UnlockFileRemoteOperation extends RemoteOperation<Void> {
     public UnlockFileRemoteOperation(long localId, String token) {
         this.localId = localId;
         this.token = token;
+        this.sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
+    }
+
+    public UnlockFileRemoteOperation(long localId, String token, SessionTimeOut sessionTimeOut) {
+        this.localId = localId;
+        this.token = token;
+        this.sessionTimeOut = sessionTimeOut;
     }
 
     /**
@@ -52,7 +61,7 @@ public class UnlockFileRemoteOperation extends RemoteOperation<Void> {
             deleteMethod.addRequestHeader(CONTENT_TYPE, FORM_URLENCODED);
             deleteMethod.addRequestHeader(E2E_TOKEN, token);
 
-            int status = client.executeMethod(deleteMethod, SYNC_READ_TIMEOUT, SYNC_CONNECTION_TIMEOUT);
+            int status = client.executeMethod(deleteMethod, sessionTimeOut.getReadTimeOut(), sessionTimeOut.getConnectionTimeOut());
 
             result = new RemoteOperationResult<>(status == HttpStatus.SC_OK, deleteMethod);
             

--- a/library/src/main/java/com/owncloud/android/lib/resources/e2ee/UnlockFileV1RemoteOperation.kt
+++ b/library/src/main/java/com/owncloud/android/lib/resources/e2ee/UnlockFileV1RemoteOperation.kt
@@ -7,6 +7,8 @@
  */
 package com.owncloud.android.lib.resources.e2ee
 
+import com.nextcloud.common.SessionTimeOut
+import com.nextcloud.common.defaultSessionTimeOut
 import com.owncloud.android.lib.common.OwnCloudClient
 import com.owncloud.android.lib.common.operations.RemoteOperation
 import com.owncloud.android.lib.common.operations.RemoteOperationResult
@@ -19,11 +21,10 @@ import org.apache.commons.httpclient.methods.DeleteMethod
  */
 class UnlockFileV1RemoteOperation(
     private val localId: Long,
-    private val token: String
+    private val token: String,
+    private val sessionTimeOut: SessionTimeOut = defaultSessionTimeOut
 ) : RemoteOperation<Void>() {
-    /**
-     * @param client Client object
-     */
+
     @Deprecated("Deprecated in Java")
     @Suppress("Detekt.TooGenericExceptionCaught")
     override fun run(client: OwnCloudClient): RemoteOperationResult<Void> {
@@ -36,7 +37,7 @@ class UnlockFileV1RemoteOperation(
             deleteMethod.addRequestHeader(CONTENT_TYPE, FORM_URLENCODED)
             deleteMethod.addRequestHeader(E2E_TOKEN, token)
             val status =
-                client.executeMethod(deleteMethod, SYNC_READ_TIMEOUT, SYNC_CONNECTION_TIMEOUT)
+                client.executeMethod(deleteMethod, sessionTimeOut.readTimeOut, sessionTimeOut.connectionTimeOut)
             result = RemoteOperationResult(status == HttpStatus.SC_OK, deleteMethod)
             client.exhaustResponse(deleteMethod.responseBodyAsStream)
         } catch (e: Exception) {
@@ -54,8 +55,6 @@ class UnlockFileV1RemoteOperation(
 
     companion object {
         private val TAG = UnlockFileV1RemoteOperation::class.java.simpleName
-        private const val SYNC_READ_TIMEOUT = 40000
-        private const val SYNC_CONNECTION_TIMEOUT = 5000
         private const val LOCK_FILE_URL = "/ocs/v2.php/apps/end_to_end_encryption/api/v1/lock/"
     }
 }

--- a/library/src/main/java/com/owncloud/android/lib/resources/e2ee/UnlockFileV1RemoteOperation.kt
+++ b/library/src/main/java/com/owncloud/android/lib/resources/e2ee/UnlockFileV1RemoteOperation.kt
@@ -19,15 +19,11 @@ import org.apache.commons.httpclient.methods.DeleteMethod
 /**
  * Unlock a file
  */
-class UnlockFileV1RemoteOperation(
+class UnlockFileV1RemoteOperation @JvmOverloads constructor(
     private val localId: Long,
-    private val token: String
+    private val token: String,
+    var sessionTimeOut: SessionTimeOut = defaultSessionTimeOut
 ) : RemoteOperation<Void>() {
-    private var sessionTimeOut: SessionTimeOut = defaultSessionTimeOut
-
-    constructor(localId: Long, token: String, sessionTimeOut: SessionTimeOut) : this(localId, token) {
-        this.sessionTimeOut = sessionTimeOut
-    }
 
     @Deprecated("Deprecated in Java")
     @Suppress("Detekt.TooGenericExceptionCaught")

--- a/library/src/main/java/com/owncloud/android/lib/resources/e2ee/UnlockFileV1RemoteOperation.kt
+++ b/library/src/main/java/com/owncloud/android/lib/resources/e2ee/UnlockFileV1RemoteOperation.kt
@@ -19,42 +19,43 @@ import org.apache.commons.httpclient.methods.DeleteMethod
 /**
  * Unlock a file
  */
-class UnlockFileV1RemoteOperation @JvmOverloads constructor(
-    private val localId: Long,
-    private val token: String,
-    private val sessionTimeOut: SessionTimeOut = defaultSessionTimeOut
-) : RemoteOperation<Void>() {
-
-    @Deprecated("Deprecated in Java")
-    @Suppress("Detekt.TooGenericExceptionCaught")
-    override fun run(client: OwnCloudClient): RemoteOperationResult<Void> {
-        var result: RemoteOperationResult<Void>
-        var deleteMethod: DeleteMethod? = null
-        try {
-            // remote request
-            deleteMethod = DeleteMethod(client.baseUri.toString() + LOCK_FILE_URL + localId)
-            deleteMethod.addRequestHeader(OCS_API_HEADER, OCS_API_HEADER_VALUE)
-            deleteMethod.addRequestHeader(CONTENT_TYPE, FORM_URLENCODED)
-            deleteMethod.addRequestHeader(E2E_TOKEN, token)
-            val status =
-                client.executeMethod(deleteMethod, sessionTimeOut.readTimeOut, sessionTimeOut.connectionTimeOut)
-            result = RemoteOperationResult(status == HttpStatus.SC_OK, deleteMethod)
-            client.exhaustResponse(deleteMethod.responseBodyAsStream)
-        } catch (e: Exception) {
-            result = RemoteOperationResult(e)
-            Log_OC.e(
-                TAG,
-                "Unlock file with id " + localId + " failed: " + result.logMessage,
-                result.exception
-            )
-        } finally {
-            deleteMethod?.releaseConnection()
+class UnlockFileV1RemoteOperation
+    @JvmOverloads
+    constructor(
+        private val localId: Long,
+        private val token: String,
+        private val sessionTimeOut: SessionTimeOut = defaultSessionTimeOut
+    ) : RemoteOperation<Void>() {
+        @Deprecated("Deprecated in Java")
+        @Suppress("Detekt.TooGenericExceptionCaught")
+        override fun run(client: OwnCloudClient): RemoteOperationResult<Void> {
+            var result: RemoteOperationResult<Void>
+            var deleteMethod: DeleteMethod? = null
+            try {
+                // remote request
+                deleteMethod = DeleteMethod(client.baseUri.toString() + LOCK_FILE_URL + localId)
+                deleteMethod.addRequestHeader(OCS_API_HEADER, OCS_API_HEADER_VALUE)
+                deleteMethod.addRequestHeader(CONTENT_TYPE, FORM_URLENCODED)
+                deleteMethod.addRequestHeader(E2E_TOKEN, token)
+                val status =
+                    client.executeMethod(deleteMethod, sessionTimeOut.readTimeOut, sessionTimeOut.connectionTimeOut)
+                result = RemoteOperationResult(status == HttpStatus.SC_OK, deleteMethod)
+                client.exhaustResponse(deleteMethod.responseBodyAsStream)
+            } catch (e: Exception) {
+                result = RemoteOperationResult(e)
+                Log_OC.e(
+                    TAG,
+                    "Unlock file with id " + localId + " failed: " + result.logMessage,
+                    result.exception
+                )
+            } finally {
+                deleteMethod?.releaseConnection()
+            }
+            return result
         }
-        return result
-    }
 
-    companion object {
-        private val TAG = UnlockFileV1RemoteOperation::class.java.simpleName
-        private const val LOCK_FILE_URL = "/ocs/v2.php/apps/end_to_end_encryption/api/v1/lock/"
+        companion object {
+            private val TAG = UnlockFileV1RemoteOperation::class.java.simpleName
+            private const val LOCK_FILE_URL = "/ocs/v2.php/apps/end_to_end_encryption/api/v1/lock/"
+        }
     }
-}

--- a/library/src/main/java/com/owncloud/android/lib/resources/e2ee/UnlockFileV1RemoteOperation.kt
+++ b/library/src/main/java/com/owncloud/android/lib/resources/e2ee/UnlockFileV1RemoteOperation.kt
@@ -21,9 +21,13 @@ import org.apache.commons.httpclient.methods.DeleteMethod
  */
 class UnlockFileV1RemoteOperation(
     private val localId: Long,
-    private val token: String,
-    private val sessionTimeOut: SessionTimeOut = defaultSessionTimeOut
+    private val token: String
 ) : RemoteOperation<Void>() {
+    private var sessionTimeOut: SessionTimeOut = defaultSessionTimeOut
+
+    constructor(localId: Long, token: String, sessionTimeOut: SessionTimeOut) : this(localId, token) {
+        this.sessionTimeOut = sessionTimeOut
+    }
 
     @Deprecated("Deprecated in Java")
     @Suppress("Detekt.TooGenericExceptionCaught")

--- a/library/src/main/java/com/owncloud/android/lib/resources/e2ee/UnlockFileV1RemoteOperation.kt
+++ b/library/src/main/java/com/owncloud/android/lib/resources/e2ee/UnlockFileV1RemoteOperation.kt
@@ -22,7 +22,7 @@ import org.apache.commons.httpclient.methods.DeleteMethod
 class UnlockFileV1RemoteOperation @JvmOverloads constructor(
     private val localId: Long,
     private val token: String,
-    var sessionTimeOut: SessionTimeOut = defaultSessionTimeOut
+    private val sessionTimeOut: SessionTimeOut = defaultSessionTimeOut
 ) : RemoteOperation<Void>() {
 
     @Deprecated("Deprecated in Java")

--- a/library/src/main/java/com/owncloud/android/lib/resources/e2ee/UpdateMetadataRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/e2ee/UpdateMetadataRemoteOperation.java
@@ -49,10 +49,7 @@ public class UpdateMetadataRemoteOperation extends RemoteOperation {
      * Constructor
      */
     public UpdateMetadataRemoteOperation(long fileId, String encryptedMetadataJson, String token) {
-        this.fileId = fileId;
-        this.encryptedMetadataJson = URLEncoder.encode(encryptedMetadataJson);
-        this.token = token;
-        sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
+        this(fileId, encryptedMetadataJson, token, SessionTimeOutKt.getDefaultSessionTimeOut());
     }
 
     public UpdateMetadataRemoteOperation(long fileId, String encryptedMetadataJson, String token, SessionTimeOut sessionTimeOut) {

--- a/library/src/main/java/com/owncloud/android/lib/resources/e2ee/UpdateMetadataRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/e2ee/UpdateMetadataRemoteOperation.java
@@ -52,7 +52,7 @@ public class UpdateMetadataRemoteOperation extends RemoteOperation {
         this.fileId = fileId;
         this.encryptedMetadataJson = URLEncoder.encode(encryptedMetadataJson);
         this.token = token;
-        this.sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
+        sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
     }
 
     public UpdateMetadataRemoteOperation(long fileId, String encryptedMetadataJson, String token, SessionTimeOut sessionTimeOut) {

--- a/library/src/main/java/com/owncloud/android/lib/resources/e2ee/UpdateMetadataV2RemoteOperation.kt
+++ b/library/src/main/java/com/owncloud/android/lib/resources/e2ee/UpdateMetadataV2RemoteOperation.kt
@@ -8,6 +8,8 @@
 package com.owncloud.android.lib.resources.e2ee
 
 import android.util.Log
+import com.nextcloud.common.SessionTimeOut
+import com.nextcloud.common.defaultSessionTimeOut
 import com.owncloud.android.lib.common.OwnCloudClient
 import com.owncloud.android.lib.common.operations.RemoteOperation
 import com.owncloud.android.lib.common.operations.RemoteOperationResult
@@ -25,7 +27,8 @@ class UpdateMetadataV2RemoteOperation(
     private val remoteId: String,
     encryptedMetadataJson: String,
     private val token: String,
-    private val signature: String
+    private val signature: String,
+    private val sessionTimeOut: SessionTimeOut = defaultSessionTimeOut
 ) : RemoteOperation<String>() {
     private val encryptedMetadataJson: String
 
@@ -62,7 +65,7 @@ class UpdateMetadataV2RemoteOperation(
                     "UTF-8"
                 )
             putMethod.requestEntity = data
-            val status = client.executeMethod(putMethod, SYNC_READ_TIMEOUT, SYNC_CONNECTION_TIMEOUT)
+            val status = client.executeMethod(putMethod, sessionTimeOut.readTimeOut, sessionTimeOut.connectionTimeOut)
             if (status == HttpStatus.SC_OK) {
                 val response = putMethod.responseBodyAsString
 
@@ -99,8 +102,6 @@ class UpdateMetadataV2RemoteOperation(
 
     companion object {
         private val TAG = UpdateMetadataV2RemoteOperation::class.java.simpleName
-        private const val SYNC_READ_TIMEOUT = 40000
-        private const val SYNC_CONNECTION_TIMEOUT = 5000
         private const val METADATA_URL = "/ocs/v2.php/apps/end_to_end_encryption/api/v2/meta-data/"
         private const val FORMAT = "format"
 

--- a/library/src/main/java/com/owncloud/android/lib/resources/e2ee/UpdateMetadataV2RemoteOperation.kt
+++ b/library/src/main/java/com/owncloud/android/lib/resources/e2ee/UpdateMetadataV2RemoteOperation.kt
@@ -23,84 +23,87 @@ import java.net.URLEncoder
 /**
  * Remote operation to update the folder metadata
  */
-class UpdateMetadataV2RemoteOperation @JvmOverloads constructor(
-    private val remoteId: String,
-    encryptedMetadataJson: String,
-    private val token: String,
-    private val signature: String,
-    private val sessionTimeOut: SessionTimeOut = defaultSessionTimeOut
-) : RemoteOperation<String>() {
-    private val encryptedMetadataJson: String = URLEncoder.encode(encryptedMetadataJson)
+class UpdateMetadataV2RemoteOperation
+    @JvmOverloads
+    constructor(
+        private val remoteId: String,
+        encryptedMetadataJson: String,
+        private val token: String,
+        private val signature: String,
+        private val sessionTimeOut: SessionTimeOut = defaultSessionTimeOut
+    ) : RemoteOperation<String>() {
+        private val encryptedMetadataJson: String = URLEncoder.encode(encryptedMetadataJson)
 
-    /**
-     * @param client Client object
-     */
-    @Deprecated("Deprecated in Java")
-    @Suppress("Detekt.TooGenericExceptionCaught")
-    override fun run(client: OwnCloudClient): RemoteOperationResult<String> {
-        var putMethod: PutMethod? = null
-        var result: RemoteOperationResult<String>
-        try {
-            // remote request
-            putMethod = PutMethod(client.baseUri.toString() + METADATA_URL + remoteId)
-            putMethod.addRequestHeader(OCS_API_HEADER, OCS_API_HEADER_VALUE)
-            putMethod.addRequestHeader(E2E_TOKEN, token)
-            putMethod.addRequestHeader(HEADER_SIGNATURE, signature)
-            putMethod.addRequestHeader(CONTENT_TYPE, FORM_URLENCODED)
-            val putParams = arrayOfNulls<NameValuePair>(1)
-            putParams[0] = NameValuePair(FORMAT, "json")
-            putMethod.setQueryString(putParams)
-            val data =
-                StringRequestEntity(
-                    "metaData=$encryptedMetadataJson",
-                    "application/json",
-                    "UTF-8"
-                )
-            putMethod.requestEntity = data
-            val status = client.executeMethod(putMethod, sessionTimeOut.readTimeOut, sessionTimeOut.connectionTimeOut)
-            if (status == HttpStatus.SC_OK) {
-                val response = putMethod.responseBodyAsString
+        /**
+         * @param client Client object
+         */
+        @Deprecated("Deprecated in Java")
+        @Suppress("Detekt.TooGenericExceptionCaught")
+        override fun run(client: OwnCloudClient): RemoteOperationResult<String> {
+            var putMethod: PutMethod? = null
+            var result: RemoteOperationResult<String>
+            try {
+                // remote request
+                putMethod = PutMethod(client.baseUri.toString() + METADATA_URL + remoteId)
+                putMethod.addRequestHeader(OCS_API_HEADER, OCS_API_HEADER_VALUE)
+                putMethod.addRequestHeader(E2E_TOKEN, token)
+                putMethod.addRequestHeader(HEADER_SIGNATURE, signature)
+                putMethod.addRequestHeader(CONTENT_TYPE, FORM_URLENCODED)
+                val putParams = arrayOfNulls<NameValuePair>(1)
+                putParams[0] = NameValuePair(FORMAT, "json")
+                putMethod.setQueryString(putParams)
+                val data =
+                    StringRequestEntity(
+                        "metaData=$encryptedMetadataJson",
+                        "application/json",
+                        "UTF-8"
+                    )
+                putMethod.requestEntity = data
+                val status =
+                    client
+                        .executeMethod(putMethod, sessionTimeOut.readTimeOut, sessionTimeOut.connectionTimeOut)
+                if (status == HttpStatus.SC_OK) {
+                    val response = putMethod.responseBodyAsString
 
-                // Parse the response
-                val respJSON = JSONObject(response)
-                val metadata =
-                    respJSON
-                        .getJSONObject(NODE_OCS)
-                        .getJSONObject(NODE_DATA)
-                        .getString(NODE_META_DATA)
-                result = RemoteOperationResult(true, putMethod)
-                result.setResultData(metadata)
-            } else {
-                result = RemoteOperationResult(false, putMethod)
+                    val respJSON = JSONObject(response)
+                    val metadata =
+                        respJSON
+                            .getJSONObject(NODE_OCS)
+                            .getJSONObject(NODE_DATA)
+                            .getString(NODE_META_DATA)
+                    result = RemoteOperationResult(true, putMethod)
+                    result.setResultData(metadata)
+                } else {
+                    result = RemoteOperationResult(false, putMethod)
+                    Log.e(
+                        TAG,
+                        "Updating metadata for folder " + remoteId + " failed: " + putMethod.responseBodyAsString,
+                        result.exception
+                    )
+                    client.exhaustResponse(putMethod.responseBodyAsStream)
+                }
+            } catch (e: Exception) {
+                result = RemoteOperationResult(e)
                 Log.e(
                     TAG,
-                    "Updating metadata for folder " + remoteId + " failed: " + putMethod.responseBodyAsString,
+                    "Updating metadata for folder " + remoteId + " failed: " + result.logMessage,
                     result.exception
                 )
-                client.exhaustResponse(putMethod.responseBodyAsStream)
+            } finally {
+                putMethod?.releaseConnection()
             }
-        } catch (e: Exception) {
-            result = RemoteOperationResult(e)
-            Log.e(
-                TAG,
-                "Updating metadata for folder " + remoteId + " failed: " + result.logMessage,
-                result.exception
-            )
-        } finally {
-            putMethod?.releaseConnection()
+            return result
         }
-        return result
-    }
 
-    companion object {
-        private val TAG = UpdateMetadataV2RemoteOperation::class.java.simpleName
-        private const val METADATA_URL = "/ocs/v2.php/apps/end_to_end_encryption/api/v2/meta-data/"
-        private const val FORMAT = "format"
+        companion object {
+            private val TAG = UpdateMetadataV2RemoteOperation::class.java.simpleName
+            private const val METADATA_URL = "/ocs/v2.php/apps/end_to_end_encryption/api/v2/meta-data/"
+            private const val FORMAT = "format"
 
-        // JSON node names
-        private const val NODE_OCS = "ocs"
-        private const val NODE_DATA = "data"
-        private const val NODE_META_DATA = "meta-data"
-        private const val HEADER_SIGNATURE = "X-NC-E2EE-SIGNATURE"
+            // JSON node names
+            private const val NODE_OCS = "ocs"
+            private const val NODE_DATA = "data"
+            private const val NODE_META_DATA = "meta-data"
+            private const val HEADER_SIGNATURE = "X-NC-E2EE-SIGNATURE"
+        }
     }
-}

--- a/library/src/main/java/com/owncloud/android/lib/resources/e2ee/UpdateMetadataV2RemoteOperation.kt
+++ b/library/src/main/java/com/owncloud/android/lib/resources/e2ee/UpdateMetadataV2RemoteOperation.kt
@@ -23,32 +23,14 @@ import java.net.URLEncoder
 /**
  * Remote operation to update the folder metadata
  */
-class UpdateMetadataV2RemoteOperation(
+class UpdateMetadataV2RemoteOperation @JvmOverloads constructor(
     private val remoteId: String,
     encryptedMetadataJson: String,
     private val token: String,
-    private val signature: String
+    private val signature: String,
+    var sessionTimeOut: SessionTimeOut = defaultSessionTimeOut
 ) : RemoteOperation<String>() {
-    private val encryptedMetadataJson: String
-    private var sessionTimeOut: SessionTimeOut = defaultSessionTimeOut
-
-    /**
-     * Constructor
-     */
-    init {
-        this.encryptedMetadataJson = URLEncoder.encode(encryptedMetadataJson)
-        // this.encryptedMetadataJson = encryptedMetadataJson;
-    }
-
-    constructor(
-        remoteId: String,
-        encryptedMetadataJson: String,
-        token: String,
-        signature: String,
-        sessionTimeOut: SessionTimeOut
-    ) : this(remoteId, encryptedMetadataJson, token, signature) {
-        this.sessionTimeOut = sessionTimeOut
-    }
+    private val encryptedMetadataJson: String = URLEncoder.encode(encryptedMetadataJson)
 
     /**
      * @param client Client object

--- a/library/src/main/java/com/owncloud/android/lib/resources/e2ee/UpdateMetadataV2RemoteOperation.kt
+++ b/library/src/main/java/com/owncloud/android/lib/resources/e2ee/UpdateMetadataV2RemoteOperation.kt
@@ -28,7 +28,7 @@ class UpdateMetadataV2RemoteOperation @JvmOverloads constructor(
     encryptedMetadataJson: String,
     private val token: String,
     private val signature: String,
-    var sessionTimeOut: SessionTimeOut = defaultSessionTimeOut
+    private val sessionTimeOut: SessionTimeOut = defaultSessionTimeOut
 ) : RemoteOperation<String>() {
     private val encryptedMetadataJson: String = URLEncoder.encode(encryptedMetadataJson)
 

--- a/library/src/main/java/com/owncloud/android/lib/resources/e2ee/UpdateMetadataV2RemoteOperation.kt
+++ b/library/src/main/java/com/owncloud/android/lib/resources/e2ee/UpdateMetadataV2RemoteOperation.kt
@@ -27,10 +27,10 @@ class UpdateMetadataV2RemoteOperation(
     private val remoteId: String,
     encryptedMetadataJson: String,
     private val token: String,
-    private val signature: String,
-    private val sessionTimeOut: SessionTimeOut = defaultSessionTimeOut
+    private val signature: String
 ) : RemoteOperation<String>() {
     private val encryptedMetadataJson: String
+    private var sessionTimeOut: SessionTimeOut = defaultSessionTimeOut
 
     /**
      * Constructor
@@ -38,6 +38,16 @@ class UpdateMetadataV2RemoteOperation(
     init {
         this.encryptedMetadataJson = URLEncoder.encode(encryptedMetadataJson)
         // this.encryptedMetadataJson = encryptedMetadataJson;
+    }
+
+    constructor(
+        remoteId: String,
+        encryptedMetadataJson: String,
+        token: String,
+        signature: String,
+        sessionTimeOut: SessionTimeOut
+    ) : this(remoteId,encryptedMetadataJson, token, signature) {
+        this.sessionTimeOut = sessionTimeOut
     }
 
     /**

--- a/library/src/main/java/com/owncloud/android/lib/resources/e2ee/UpdateMetadataV2RemoteOperation.kt
+++ b/library/src/main/java/com/owncloud/android/lib/resources/e2ee/UpdateMetadataV2RemoteOperation.kt
@@ -46,7 +46,7 @@ class UpdateMetadataV2RemoteOperation(
         token: String,
         signature: String,
         sessionTimeOut: SessionTimeOut
-    ) : this(remoteId,encryptedMetadataJson, token, signature) {
+    ) : this(remoteId, encryptedMetadataJson, token, signature) {
         this.sessionTimeOut = sessionTimeOut
     }
 

--- a/library/src/main/java/com/owncloud/android/lib/resources/files/CheckEtagRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/files/CheckEtagRemoteOperation.java
@@ -41,7 +41,7 @@ public class CheckEtagRemoteOperation extends RemoteOperation {
     public CheckEtagRemoteOperation(String path, String expectedEtag) {
         this.path = path;
         this.expectedEtag = expectedEtag;
-        this.sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
+        sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
     }
 
     public CheckEtagRemoteOperation(String path, String expectedEtag, SessionTimeOut sessionTimeOut) {

--- a/library/src/main/java/com/owncloud/android/lib/resources/files/CheckEtagRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/files/CheckEtagRemoteOperation.java
@@ -7,6 +7,8 @@
  */
 package com.owncloud.android.lib.resources.files;
 
+import com.nextcloud.common.SessionTimeOut;
+import com.nextcloud.common.SessionTimeOutKt;
 import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.common.network.WebdavUtils;
 import com.owncloud.android.lib.common.operations.RemoteOperation;
@@ -29,18 +31,24 @@ import java.util.ArrayList;
  */
 public class CheckEtagRemoteOperation extends RemoteOperation {
 
-    private static final int SYNC_READ_TIMEOUT = 40000;
-    private static final int SYNC_CONNECTION_TIMEOUT = 5000;
     private static final String TAG = CheckEtagRemoteOperation.class.getSimpleName();
 
     private String path;
     private String expectedEtag;
 
+    private final SessionTimeOut sessionTimeOut;
+
     public CheckEtagRemoteOperation(String path, String expectedEtag) {
         this.path = path;
         this.expectedEtag = expectedEtag;
+        this.sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
     }
 
+    public CheckEtagRemoteOperation(String path, String expectedEtag, SessionTimeOut sessionTimeOut) {
+        this.path = path;
+        this.expectedEtag = expectedEtag;
+        this.sessionTimeOut = sessionTimeOut;
+    }
 
     @Override
     protected RemoteOperationResult run(OwnCloudClient client) {
@@ -53,7 +61,7 @@ public class CheckEtagRemoteOperation extends RemoteOperation {
             propfind = new PropFindMethod(client.getFilesDavUri(path),
                     propSet,
                     0);
-            int status = client.executeMethod(propfind, SYNC_READ_TIMEOUT, SYNC_CONNECTION_TIMEOUT);
+            int status = client.executeMethod(propfind, sessionTimeOut.getReadTimeOut(), sessionTimeOut.getConnectionTimeOut());
 
             if (status == HttpStatus.SC_MULTI_STATUS || status == HttpStatus.SC_OK) {
                 MultiStatusResponse resp = propfind.getResponseBodyAsMultiStatus().getResponses()[0];
@@ -62,9 +70,9 @@ public class CheckEtagRemoteOperation extends RemoteOperation {
                         .get(DavPropertyName.GETETAG).getValue());
 
                 if (etag.equals(expectedEtag)) {
-                    return new RemoteOperationResult(ResultCode.ETAG_UNCHANGED);
+                    return new RemoteOperationResult<>(ResultCode.ETAG_UNCHANGED);
                 } else {
-                    RemoteOperationResult result = new RemoteOperationResult(ResultCode.ETAG_CHANGED);
+                    final var result = new RemoteOperationResult<>(ResultCode.ETAG_CHANGED);
 
                     ArrayList<Object> list = new ArrayList<>();
                     list.add(etag);
@@ -75,7 +83,7 @@ public class CheckEtagRemoteOperation extends RemoteOperation {
             }
 
             if (status == HttpStatus.SC_NOT_FOUND) {
-                return new RemoteOperationResult(ResultCode.FILE_NOT_FOUND);
+                return new RemoteOperationResult<>(ResultCode.FILE_NOT_FOUND);
             }
         } catch (DavException | IOException e) {
             Log_OC.e(TAG, "Error while retrieving eTag");
@@ -85,6 +93,6 @@ public class CheckEtagRemoteOperation extends RemoteOperation {
             }
         }
 
-        return new RemoteOperationResult(ResultCode.ETAG_CHANGED);
+        return new RemoteOperationResult<>(ResultCode.ETAG_CHANGED);
     }
 }

--- a/library/src/main/java/com/owncloud/android/lib/resources/files/CheckEtagRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/files/CheckEtagRemoteOperation.java
@@ -33,15 +33,13 @@ public class CheckEtagRemoteOperation extends RemoteOperation {
 
     private static final String TAG = CheckEtagRemoteOperation.class.getSimpleName();
 
-    private String path;
-    private String expectedEtag;
+    private final String path;
+    private final String expectedEtag;
 
     private final SessionTimeOut sessionTimeOut;
 
     public CheckEtagRemoteOperation(String path, String expectedEtag) {
-        this.path = path;
-        this.expectedEtag = expectedEtag;
-        sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
+        this(path, expectedEtag, SessionTimeOutKt.getDefaultSessionTimeOut());
     }
 
     public CheckEtagRemoteOperation(String path, String expectedEtag, SessionTimeOut sessionTimeOut) {

--- a/library/src/main/java/com/owncloud/android/lib/resources/files/CopyFileRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/files/CopyFileRemoteOperation.java
@@ -53,10 +53,7 @@ public class CopyFileRemoteOperation extends RemoteOperation {
      * @param targetRemotePath Remove path desired for the file/folder after moving it.
      */
     public CopyFileRemoteOperation(String srcRemotePath, String targetRemotePath, boolean overwrite) {
-        mSrcRemotePath = srcRemotePath;
-        mTargetRemotePath = targetRemotePath;
-        mOverwrite = overwrite;
-        this.sessionTimeOut = new SessionTimeOut(600000, 5000);
+        this(srcRemotePath, targetRemotePath, overwrite, new SessionTimeOut(600000, 5000));
     }
 
 

--- a/library/src/main/java/com/owncloud/android/lib/resources/files/CopyFileRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/files/CopyFileRemoteOperation.java
@@ -9,6 +9,7 @@ package com.owncloud.android.lib.resources.files;
 import android.util.Log;
 
 import com.nextcloud.common.SessionTimeOut;
+import com.nextcloud.common.SessionTimeOutKt;
 import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.common.operations.RemoteOperation;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
@@ -53,7 +54,7 @@ public class CopyFileRemoteOperation extends RemoteOperation {
      * @param targetRemotePath Remove path desired for the file/folder after moving it.
      */
     public CopyFileRemoteOperation(String srcRemotePath, String targetRemotePath, boolean overwrite) {
-        this(srcRemotePath, targetRemotePath, overwrite, new SessionTimeOut(600000, 5000));
+        this(srcRemotePath, targetRemotePath, overwrite, SessionTimeOutKt.getDefaultSessionTimeOut());
     }
 
 

--- a/library/src/main/java/com/owncloud/android/lib/resources/files/CreateFolderRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/files/CreateFolderRemoteOperation.java
@@ -8,6 +8,8 @@ package com.owncloud.android.lib.resources.files;
 
 import android.text.TextUtils;
 
+import com.nextcloud.common.SessionTimeOut;
+import com.nextcloud.common.SessionTimeOutKt;
 import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.common.operations.RemoteOperation;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
@@ -28,13 +30,11 @@ public class CreateFolderRemoteOperation extends RemoteOperation<String> {
 
     private static final String TAG = CreateFolderRemoteOperation.class.getSimpleName();
 
-    private static final int READ_TIMEOUT = 30000;
-    private static final int CONNECTION_TIMEOUT = 5000;
 
-
-    private boolean createFullPath;
-    private String remotePath;
+    private final boolean createFullPath;
+    private final String remotePath;
     private String token;
+    private final SessionTimeOut sessionTimeOut;
 
     /**
      * Constructor
@@ -46,11 +46,25 @@ public class CreateFolderRemoteOperation extends RemoteOperation<String> {
     public CreateFolderRemoteOperation(String remotePath, boolean createFullPath) {
         this.remotePath = remotePath;
         this.createFullPath = createFullPath;
+        this.sessionTimeOut = new SessionTimeOut(30000, 5000);
     }
 
     public CreateFolderRemoteOperation(String remotePath, boolean createFullPath, String token) {
         this(remotePath, createFullPath);
         this.token = token;
+    }
+
+    public CreateFolderRemoteOperation(String remotePath, boolean createFullPath, SessionTimeOut sessionTimeOut) {
+        this.remotePath = remotePath;
+        this.createFullPath = createFullPath;
+        this.sessionTimeOut = sessionTimeOut;
+    }
+
+    public CreateFolderRemoteOperation(String remotePath, boolean createFullPath, String token, SessionTimeOut sessionTimeOut) {
+        this.remotePath = remotePath;
+        this.createFullPath = createFullPath;
+        this.token = token;
+        this.sessionTimeOut = sessionTimeOut;
     }
 
     /**
@@ -86,7 +100,7 @@ public class CreateFolderRemoteOperation extends RemoteOperation<String> {
                 mkCol.addRequestHeader(E2E_TOKEN, token);
             }
 
-            client.executeMethod(mkCol, READ_TIMEOUT, CONNECTION_TIMEOUT);
+            client.executeMethod(mkCol, sessionTimeOut.getReadTimeOut(), sessionTimeOut.getConnectionTimeOut());
 
             if (HttpStatus.SC_METHOD_NOT_ALLOWED == mkCol.getStatusCode()) {
                 result = new RemoteOperationResult<>(RemoteOperationResult.ResultCode.FOLDER_ALREADY_EXISTS);
@@ -120,6 +134,4 @@ public class CreateFolderRemoteOperation extends RemoteOperation<String> {
         RemoteOperation<String> operation = new CreateFolderRemoteOperation(parentPath, createFullPath);
         return operation.execute(client);
     }
-
-
 }

--- a/library/src/main/java/com/owncloud/android/lib/resources/files/CreateFolderRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/files/CreateFolderRemoteOperation.java
@@ -33,7 +33,7 @@ public class CreateFolderRemoteOperation extends RemoteOperation<String> {
 
     private final boolean createFullPath;
     private final String remotePath;
-    private String token;
+    private final String token;
     private final SessionTimeOut sessionTimeOut;
 
     /**
@@ -44,20 +44,15 @@ public class CreateFolderRemoteOperation extends RemoteOperation<String> {
      *                       if don't exist yet.
      */
     public CreateFolderRemoteOperation(String remotePath, boolean createFullPath) {
-        this.remotePath = remotePath;
-        this.createFullPath = createFullPath;
-        this.sessionTimeOut = new SessionTimeOut(30000, 5000);
+        this(remotePath, createFullPath, SessionTimeOutKt.getDefaultSessionTimeOut());
     }
 
     public CreateFolderRemoteOperation(String remotePath, boolean createFullPath, String token) {
-        this(remotePath, createFullPath);
-        this.token = token;
+        this(remotePath, createFullPath, token, SessionTimeOutKt.getDefaultSessionTimeOut());
     }
 
     public CreateFolderRemoteOperation(String remotePath, boolean createFullPath, SessionTimeOut sessionTimeOut) {
-        this.remotePath = remotePath;
-        this.createFullPath = createFullPath;
-        this.sessionTimeOut = sessionTimeOut;
+        this(remotePath, createFullPath, "", sessionTimeOut);
     }
 
     public CreateFolderRemoteOperation(String remotePath, boolean createFullPath, String token, SessionTimeOut sessionTimeOut) {

--- a/library/src/main/java/com/owncloud/android/lib/resources/files/MoveFileRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/files/MoveFileRemoteOperation.java
@@ -51,10 +51,7 @@ public class MoveFileRemoteOperation extends RemoteOperation {
      * @param targetRemotePath Remove path desired for the file/folder after moving it.
      */
     public MoveFileRemoteOperation(String srcRemotePath, String targetRemotePath, boolean overwrite) {
-        mSrcRemotePath = srcRemotePath;
-        mTargetRemotePath = targetRemotePath;
-        mOverwrite = overwrite;
-        sessionTimeOut = new SessionTimeOut(600000, 5000);
+        this(srcRemotePath, targetRemotePath, overwrite, SessionTimeOutKt.getDefaultSessionTimeOut());
     }
 
     public MoveFileRemoteOperation(String srcRemotePath, String targetRemotePath, boolean overwrite, SessionTimeOut sessionTimeOut) {

--- a/library/src/main/java/com/owncloud/android/lib/resources/files/MoveFileRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/files/MoveFileRemoteOperation.java
@@ -8,6 +8,8 @@ package com.owncloud.android.lib.resources.files;
 
 import android.util.Log;
 
+import com.nextcloud.common.SessionTimeOut;
+import com.nextcloud.common.SessionTimeOutKt;
 import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.common.operations.RemoteOperation;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
@@ -33,13 +35,11 @@ public class MoveFileRemoteOperation extends RemoteOperation {
 
     private static final String TAG = MoveFileRemoteOperation.class.getSimpleName();
 
-    private static final int MOVE_READ_TIMEOUT = 600000;
-    private static final int MOVE_CONNECTION_TIMEOUT = 5000;
+    private final String mSrcRemotePath;
+    private final String mTargetRemotePath;
+    private final boolean mOverwrite;
 
-    private String mSrcRemotePath;
-    private String mTargetRemotePath;
-
-    private boolean mOverwrite;
+    private final SessionTimeOut sessionTimeOut;
 
 
     /**
@@ -50,13 +50,18 @@ public class MoveFileRemoteOperation extends RemoteOperation {
      * @param srcRemotePath    Remote path of the file/folder to move.
      * @param targetRemotePath Remove path desired for the file/folder after moving it.
      */
-    public MoveFileRemoteOperation(
-        String srcRemotePath, String targetRemotePath, boolean overwrite
-    ) {
-
+    public MoveFileRemoteOperation(String srcRemotePath, String targetRemotePath, boolean overwrite) {
         mSrcRemotePath = srcRemotePath;
         mTargetRemotePath = targetRemotePath;
         mOverwrite = overwrite;
+        sessionTimeOut = new SessionTimeOut(600000, 5000);
+    }
+
+    public MoveFileRemoteOperation(String srcRemotePath, String targetRemotePath, boolean overwrite, SessionTimeOut sessionTimeOut) {
+        mSrcRemotePath = srcRemotePath;
+        mTargetRemotePath = targetRemotePath;
+        mOverwrite = overwrite;
+        this.sessionTimeOut = sessionTimeOut;
     }
 
 
@@ -70,11 +75,11 @@ public class MoveFileRemoteOperation extends RemoteOperation {
         // check parameters
         if (mTargetRemotePath.equals(mSrcRemotePath)) {
             // nothing to do!
-            return new RemoteOperationResult(ResultCode.OK);
+            return new RemoteOperationResult<>(ResultCode.OK);
         }
 
         if (mTargetRemotePath.startsWith(mSrcRemotePath)) {
-            return new RemoteOperationResult(ResultCode.INVALID_MOVE_INTO_DESCENDANT);
+            return new RemoteOperationResult<>(ResultCode.INVALID_MOVE_INTO_DESCENDANT);
         }
 
 
@@ -87,7 +92,7 @@ public class MoveFileRemoteOperation extends RemoteOperation {
                     client.getFilesDavUri(mTargetRemotePath),
                     mOverwrite
             );
-            int status = client.executeMethod(move, MOVE_READ_TIMEOUT, MOVE_CONNECTION_TIMEOUT);
+            int status = client.executeMethod(move, sessionTimeOut.getReadTimeOut(), sessionTimeOut.getConnectionTimeOut());
 
             /// process response
             if (status == HttpStatus.SC_MULTI_STATUS) {
@@ -103,7 +108,7 @@ public class MoveFileRemoteOperation extends RemoteOperation {
                 /// http://www.webdav.org/specs/rfc4918.html#rfc.section.9.9.4
 
             } else {
-                result = new RemoteOperationResult(isSuccess(status), move);
+                result = new RemoteOperationResult<>(isSuccess(status), move);
                 client.exhaustResponse(move.getResponseBodyAsStream());
             }
 
@@ -111,7 +116,7 @@ public class MoveFileRemoteOperation extends RemoteOperation {
                 result.getLogMessage());
 
         } catch (Exception e) {
-            result = new RemoteOperationResult(e);
+            result = new RemoteOperationResult<>(e);
             Log.e(TAG, "Move " + mSrcRemotePath + " to " + mTargetRemotePath + ": " +
                 result.getLogMessage(), e);
 
@@ -160,18 +165,15 @@ public class MoveFileRemoteOperation extends RemoteOperation {
 
         RemoteOperationResult result;
         if (failFound) {
-            result = new RemoteOperationResult(ResultCode.PARTIAL_MOVE_DONE);
+            result = new RemoteOperationResult<>(ResultCode.PARTIAL_MOVE_DONE);
         } else {
-            result = new RemoteOperationResult(true, move);
+            result = new RemoteOperationResult<>(true, move);
         }
 
         return result;
-
     }
-
 
     protected boolean isSuccess(int status) {
         return status == HttpStatus.SC_CREATED || status == HttpStatus.SC_NO_CONTENT;
     }
-
 }

--- a/library/src/main/java/com/owncloud/android/lib/resources/files/ReadFileRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/files/ReadFileRemoteOperation.java
@@ -6,6 +6,8 @@
  */
 package com.owncloud.android.lib.resources.files;
 
+import com.nextcloud.common.SessionTimeOut;
+import com.nextcloud.common.SessionTimeOutKt;
 import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.common.network.WebdavEntry;
 import com.owncloud.android.lib.common.network.WebdavUtils;
@@ -32,10 +34,8 @@ import java.util.ArrayList;
 public class ReadFileRemoteOperation extends RemoteOperation {
 
     private static final String TAG = ReadFileRemoteOperation.class.getSimpleName();
-    private static final int SYNC_READ_TIMEOUT = 40000;
-    private static final int SYNC_CONNECTION_TIMEOUT = 5000;
-
-    private String mRemotePath;
+    private final String mRemotePath;
+    private final SessionTimeOut sessionTimeOut;
 
 
     /**
@@ -45,6 +45,12 @@ public class ReadFileRemoteOperation extends RemoteOperation {
      */
     public ReadFileRemoteOperation(String remotePath) {
         mRemotePath = remotePath;
+        sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
+    }
+
+    public ReadFileRemoteOperation(String remotePath, SessionTimeOut sessionTimeOut) {
+        mRemotePath = remotePath;
+        this.sessionTimeOut = sessionTimeOut;
     }
 
     /**
@@ -64,7 +70,7 @@ public class ReadFileRemoteOperation extends RemoteOperation {
                     WebdavUtils.getFilePropSet(),    // PropFind Properties
                     DavConstants.DEPTH_0);
             int status;
-            status = client.executeMethod(propfind, SYNC_READ_TIMEOUT, SYNC_CONNECTION_TIMEOUT);
+            status = client.executeMethod(propfind, sessionTimeOut.getReadTimeOut(), sessionTimeOut.getConnectionTimeOut());
 
             boolean isSuccess = (
                 status == HttpStatus.SC_MULTI_STATUS ||
@@ -80,16 +86,16 @@ public class ReadFileRemoteOperation extends RemoteOperation {
                 files.add(remoteFile);
 
                 // Result of the operation
-                result = new RemoteOperationResult(true, propfind);
+                result = new RemoteOperationResult<>(true, propfind);
                 result.setData(files);
 
             } else {
-                result = new RemoteOperationResult(false, propfind);
+                result = new RemoteOperationResult<>(false, propfind);
                 client.exhaustResponse(propfind.getResponseBodyAsStream());
             }
 
         } catch (Exception e) {
-            result = new RemoteOperationResult(e);
+            result = new RemoteOperationResult<>(e);
             Log_OC.e(TAG, "Read file " + mRemotePath + " failed: " + result.getLogMessage(),
                 result.getException());
         } finally {
@@ -98,5 +104,4 @@ public class ReadFileRemoteOperation extends RemoteOperation {
         }
         return result;
     }
-
 }

--- a/library/src/main/java/com/owncloud/android/lib/resources/files/ReadFileRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/files/ReadFileRemoteOperation.java
@@ -44,8 +44,7 @@ public class ReadFileRemoteOperation extends RemoteOperation {
      * @param remotePath Remote path of the file.
      */
     public ReadFileRemoteOperation(String remotePath) {
-        mRemotePath = remotePath;
-        sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
+        this(remotePath, SessionTimeOutKt.getDefaultSessionTimeOut());
     }
 
     public ReadFileRemoteOperation(String remotePath, SessionTimeOut sessionTimeOut) {

--- a/library/src/main/java/com/owncloud/android/lib/resources/files/RemoveFileRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/files/RemoveFileRemoteOperation.java
@@ -34,8 +34,7 @@ public class RemoveFileRemoteOperation extends RemoteOperation {
      * @param remotePath RemotePath of the remote file or folder to remove from the server
      */
     public RemoveFileRemoteOperation(String remotePath) {
-        mRemotePath = remotePath;
-        sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
+        this(remotePath, SessionTimeOutKt.getDefaultSessionTimeOut());
     }
 
     public RemoveFileRemoteOperation(String remotePath, SessionTimeOut sessionTimeOut) {

--- a/library/src/main/java/com/owncloud/android/lib/resources/files/RenameFileRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/files/RenameFileRemoteOperation.java
@@ -46,7 +46,7 @@ public class RenameFileRemoteOperation extends RemoteOperation {
      * @param isFolder      'true' for folder and 'false' for files
      */
     public RenameFileRemoteOperation(String oldName, String oldRemotePath, String newName, boolean isFolder) {
-        this(oldName, oldRemotePath, newName, isFolder, new SessionTimeOut(600000, 5000));
+        this(oldName, oldRemotePath, newName, isFolder, SessionTimeOutKt.getDefaultSessionTimeOut());
     }
 
     public RenameFileRemoteOperation(String oldName, String oldRemotePath, String newName, boolean isFolder, SessionTimeOut sessionTimeOut) {

--- a/library/src/main/java/com/owncloud/android/lib/resources/files/RestoreFileVersionRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/files/RestoreFileVersionRemoteOperation.java
@@ -43,7 +43,7 @@ public class RestoreFileVersionRemoteOperation extends RemoteOperation {
     public RestoreFileVersionRemoteOperation(long fileId, String fileName) {
         this.fileId = fileId;
         this.fileName = fileName;
-        this.sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
+        sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
     }
 
     public RestoreFileVersionRemoteOperation(long fileId, String fileName, SessionTimeOut sessionTimeOut) {

--- a/library/src/main/java/com/owncloud/android/lib/resources/files/RestoreFileVersionRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/files/RestoreFileVersionRemoteOperation.java
@@ -41,9 +41,7 @@ public class RestoreFileVersionRemoteOperation extends RemoteOperation {
      * @param fileName version date in unixtime
      */
     public RestoreFileVersionRemoteOperation(long fileId, String fileName) {
-        this.fileId = fileId;
-        this.fileName = fileName;
-        sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
+        this(fileId, fileName, SessionTimeOutKt.getDefaultSessionTimeOut());
     }
 
     public RestoreFileVersionRemoteOperation(long fileId, String fileName, SessionTimeOut sessionTimeOut) {

--- a/library/src/main/java/com/owncloud/android/lib/resources/trashbin/RemoveTrashbinFileRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/trashbin/RemoveTrashbinFileRemoteOperation.java
@@ -34,7 +34,7 @@ public class RemoveTrashbinFileRemoteOperation extends RemoteOperation {
      */
     public RemoveTrashbinFileRemoteOperation(String remotePath) {
         this.remotePath = remotePath;
-        this.sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
+        sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
     }
 
     public RemoveTrashbinFileRemoteOperation(String remotePath, SessionTimeOut sessionTimeOut) {

--- a/library/src/main/java/com/owncloud/android/lib/resources/trashbin/RemoveTrashbinFileRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/trashbin/RemoveTrashbinFileRemoteOperation.java
@@ -33,8 +33,7 @@ public class RemoveTrashbinFileRemoteOperation extends RemoteOperation {
      * @param remotePath RemotePath of the remote file or folder to remove from the server
      */
     public RemoveTrashbinFileRemoteOperation(String remotePath) {
-        this.remotePath = remotePath;
-        sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
+        this(remotePath, SessionTimeOutKt.getDefaultSessionTimeOut());
     }
 
     public RemoveTrashbinFileRemoteOperation(String remotePath, SessionTimeOut sessionTimeOut) {

--- a/library/src/main/java/com/owncloud/android/lib/resources/trashbin/RestoreTrashbinFileRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/trashbin/RestoreTrashbinFileRemoteOperation.java
@@ -41,9 +41,7 @@ public class RestoreTrashbinFileRemoteOperation extends RemoteOperation {
      * @param fileName   original filename
      */
     public RestoreTrashbinFileRemoteOperation(String sourcePath, String fileName) {
-        this.sourcePath = sourcePath;
-        this.fileName = fileName;
-        sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
+        this(sourcePath, fileName, SessionTimeOutKt.getDefaultSessionTimeOut());
     }
 
     public RestoreTrashbinFileRemoteOperation(String sourcePath, String fileName, SessionTimeOut sessionTimeOut) {

--- a/library/src/main/java/com/owncloud/android/lib/resources/users/CheckRemoteWipeRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/users/CheckRemoteWipeRemoteOperation.java
@@ -33,7 +33,7 @@ public class CheckRemoteWipeRemoteOperation extends RemoteOperation {
     private final SessionTimeOut sessionTimeOut;
 
     public CheckRemoteWipeRemoteOperation() {
-        sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
+        this(SessionTimeOutKt.getDefaultSessionTimeOut());
     }
 
     public CheckRemoteWipeRemoteOperation(SessionTimeOut sessionTimeOut) {

--- a/library/src/main/java/com/owncloud/android/lib/resources/users/RemoteWipeSuccessRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/users/RemoteWipeSuccessRemoteOperation.java
@@ -31,8 +31,7 @@ public class RemoteWipeSuccessRemoteOperation extends RemoteOperation {
     private final SessionTimeOut sessionTimeOut;
 
     public RemoteWipeSuccessRemoteOperation(String appToken) {
-        this.appToken = appToken;
-        sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
+        this(appToken, SessionTimeOutKt.getDefaultSessionTimeOut());
     }
 
     public RemoteWipeSuccessRemoteOperation(String appToken, SessionTimeOut sessionTimeOut) {

--- a/library/src/main/java/com/owncloud/android/lib/resources/users/RemoteWipeSuccessRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/users/RemoteWipeSuccessRemoteOperation.java
@@ -7,6 +7,8 @@
  */
 package com.owncloud.android.lib.resources.users;
 
+import com.nextcloud.common.SessionTimeOut;
+import com.nextcloud.common.SessionTimeOutKt;
 import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.common.operations.RemoteOperation;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
@@ -23,14 +25,19 @@ import org.apache.commons.httpclient.methods.Utf8PostMethod;
 public class RemoteWipeSuccessRemoteOperation extends RemoteOperation {
 
     private static final String TAG = RemoteWipeSuccessRemoteOperation.class.getSimpleName();
-    private static final int SYNC_READ_TIMEOUT = 40000;
-    private static final int SYNC_CONNECTION_TIMEOUT = 5000;
     private static final String REMOTE_WIPE_URL = "/index.php/core/wipe/success";
 
-    private String appToken;
+    private final String appToken;
+    private final SessionTimeOut sessionTimeOut;
 
     public RemoteWipeSuccessRemoteOperation(String appToken) {
         this.appToken = appToken;
+        sessionTimeOut = SessionTimeOutKt.getDefaultSessionTimeOut();
+    }
+
+    public RemoteWipeSuccessRemoteOperation(String appToken, SessionTimeOut sessionTimeOut) {
+        this.appToken = appToken;
+        this.sessionTimeOut = sessionTimeOut;
     }
 
     /**
@@ -46,17 +53,17 @@ public class RemoteWipeSuccessRemoteOperation extends RemoteOperation {
             postMethod.addRequestHeader(CONTENT_TYPE, FORM_URLENCODED);
             postMethod.setParameter(REMOTE_WIPE_TOKEN, appToken);
 
-            int status = client.executeMethod(postMethod, SYNC_READ_TIMEOUT, SYNC_CONNECTION_TIMEOUT);
+            int status = client.executeMethod(postMethod, sessionTimeOut.getReadTimeOut(), sessionTimeOut.getConnectionTimeOut());
             client.exhaustResponse(postMethod.getResponseBodyAsStream());
 
             if (HttpStatus.SC_OK == status) {
-                result = new RemoteOperationResult(RemoteOperationResult.ResultCode.OK);
+                result = new RemoteOperationResult<>(RemoteOperationResult.ResultCode.OK);
             } else {
-                result = new RemoteOperationResult(
+                result = new RemoteOperationResult<>(
                         RemoteOperationResult.ResultCode.valueOf(String.valueOf(status)));
             }
         } catch (Exception e) {
-            result = new RemoteOperationResult(e);
+            result = new RemoteOperationResult<>(e);
             Log_OC.e(TAG,
                      "Setting status of remote wipe status failed: " + result.getLogMessage(),
                      result.getException());


### PR DESCRIPTION
The client must be able to modify the session timeout according to their needs. For example, if the server instance slow, some network operations may fail. This could lead to issues, especially during end-to-end (E2E) operations.

**Changes**

SessionTimeOut data class has been added.
The default SessionTimeOut is utilized for each remote operation in the first constructor.
A second constructor has been added to allow custom SessionTimeOut injection for each remote operation.

**How to Test?**

Files client must build without any compile error
Files client must be able to configure SessionTimeOut for any remote operations