### PR TITLE
Extend OCCapability to include notes folder location

### DIFF
--- a/library/src/main/java/com/owncloud/android/lib/resources/status/GetCapabilitiesRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/status/GetCapabilitiesRemoteOperation.java
@@ -173,6 +173,10 @@ public class GetCapabilitiesRemoteOperation extends RemoteOperation {
     private static final String NODE_FILES_DOWNLOAD_LIMIT = "downloadlimit";
     private static final String FILES_DOWNLOAD_LIMIT_DEFAULT = "default-limit";
 
+    // notes folder location
+    private static final String NODE_NOTES = "notes";
+    private static final String NOTES_PATH = "notes_path";
+
     private OCCapability currentCapability = null;
 
     public GetCapabilitiesRemoteOperation() {
@@ -770,6 +774,22 @@ public class GetCapabilitiesRemoteOperation extends RemoteOperation {
                 } else {
                     capability.setRecommendations(CapabilityBooleanType.FALSE);
                 }
+
+                // notes folder
+                if (respCapabilities.has(NODE_NOTES)) {
+                    JSONObject notesCapability = respCapabilities.getJSONObject(NODE_NOTES);
+
+                    if (notesCapability.has(NOTES_PATH)) {
+                        String notesFolderPath = notesCapability.getString(NOTES_PATH);
+
+                        if (!notesFolderPath.isEmpty() && !notesFolderPath.endsWith("/")) {
+                            notesFolderPath += "/";
+                        }
+
+                        capability.setNotesFolderPath(notesFolderPath);
+                    }
+                }
+
             }
 
             Log_OC.d(TAG, "*** Get Capabilities completed ");

--- a/library/src/main/java/com/owncloud/android/lib/resources/status/OCCapability.kt
+++ b/library/src/main/java/com/owncloud/android/lib/resources/status/OCCapability.kt
@@ -117,6 +117,9 @@ class OCCapability {
     var filesDownloadLimit = CapabilityBooleanType.UNKNOWN
     var filesDownloadLimitDefault = -1
 
+    // notes folder location
+    var notesFolderPath: String? = null
+
     // Etag for capabilities
     var etag: String? = ""
 


### PR DESCRIPTION
With this change, the android library will now be able to determine the folder where [notes](https://github.com/nextcloud/notes) are stored. This will be used to determine when to display a *Open in Notes* button in the files client according to nextcloud/notes-android#1873.

Requires nextcloud/notes#1468