### PR TITLE
Add bandwidth limit to file download and upload functions 

### DIFF
--- a/library/src/main/java/com/owncloud/android/lib/resources/files/DownloadFileRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/files/DownloadFileRemoteOperation.java
@@ -18,9 +18,12 @@ import org.apache.commons.httpclient.Header;
 import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.httpclient.methods.GetMethod;
 
-import java.io.BufferedInputStream;
+import okio.Throttler;
+import okio.Source;
+import okio.BufferedSink;
+import okio.Okio;
+
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Date;
 import java.util.HashSet;
@@ -44,6 +47,7 @@ public class DownloadFileRemoteOperation extends RemoteOperation {
     private long modificationTimestamp = 0;
     private String eTag = "";
     private GetMethod getMethod;
+    private final Throttler throttler = new Throttler();
 
     private String remotePath;
     private String temporalFolderPath;
@@ -57,8 +61,16 @@ public class DownloadFileRemoteOperation extends RemoteOperation {
         this.temporalFolderPath = temporalFolderPath;
     }
 
-	@Override
-	protected RemoteOperationResult run(OwnCloudClient client) {
+    /**
+     * @param limit Maximum download speed in bytes per second.
+     *              Disabled by default (limit 0).
+     */
+    public void setBandwidthLimit(long limit) {
+        throttler.bytesPerSecond(limit);
+    }
+
+    @Override
+    protected RemoteOperationResult run(OwnCloudClient client) {
         RemoteOperationResult result;
 
         /// download will be performed to a temporal file, then moved to the final location
@@ -88,7 +100,11 @@ public class DownloadFileRemoteOperation extends RemoteOperation {
         getMethod = new GetMethod(client.getFilesDavUri(remotePath));
         Iterator<OnDatatransferProgressListener> it;
 
-        FileOutputStream fos = null;
+        // TODO If the upload and download limits should be global then the same throttler can be used for
+        // all instances of this and the upload class.
+        Source bufferSource = null;
+        Source throttledBufferSource = null;
+        BufferedSink bufferSink = null;
         try {
             status = client.executeMethod(getMethod);
             if (isSuccess(status)) {
@@ -98,25 +114,26 @@ public class DownloadFileRemoteOperation extends RemoteOperation {
                     Log_OC.e(TAG, "Error creating file " + targetFile.getAbsolutePath(), ex);
                     throw new CreateLocalFileException(targetFile.getPath(), ex);
                 }
-                BufferedInputStream bis = new BufferedInputStream(getMethod.getResponseBodyAsStream());
-                fos = new FileOutputStream(targetFile);
+                bufferSource = Okio.source(getMethod.getResponseBodyAsStream());
+                throttledBufferSource = throttler.source(bufferSource);
+                bufferSink = Okio.buffer(Okio.sink(targetFile));
+
                 long transferred = 0;
 
                 Header contentLength = getMethod.getResponseHeader("Content-Length");
                 long totalToTransfer = (contentLength != null &&
-                        contentLength.getValue().length() > 0) ?
-                        Long.parseLong(contentLength.getValue()) : 0;
+                    contentLength.getValue().length() > 0) ?
+                    Long.parseLong(contentLength.getValue()) : 0;
 
-                byte[] bytes = new byte[4096];
-                int readResult;
-                while ((readResult = bis.read(bytes)) != -1) {
+                long readResult;
+                while ((readResult = throttledBufferSource.read(bufferSink.getBuffer(), 4096)) != -1) {
+                    bufferSink.emitCompleteSegments();
                     synchronized (mCancellationRequested) {
                         if (mCancellationRequested.get()) {
                             getMethod.abort();
                             throw new OperationCancelledException();
                         }
                     }
-                    fos.write(bytes, 0, readResult);
                     transferred += readResult;
                     synchronized (mDataTransferListeners) {
                         it = mDataTransferListeners.iterator();
@@ -126,6 +143,7 @@ public class DownloadFileRemoteOperation extends RemoteOperation {
                         }
                     }
                 }
+                bufferSink.flush();
                 // Check if the file is completed
                 // if transfer-encoding: chunked we cannot check if the file is complete
                 Header transferEncodingHeader = getMethod.getResponseHeader("Transfer-Encoding");
@@ -163,7 +181,11 @@ public class DownloadFileRemoteOperation extends RemoteOperation {
             }
 
         } finally {
-            if (fos != null) fos.close();
+            // TODO Any of these need try statements? Which of these are even necessary? (Been a while since I last dealt with buffers)
+            if (bufferSource != null) bufferSource.close();
+            if (throttledBufferSource != null) throttledBufferSource.close();
+            if (bufferSink != null) bufferSink.close();
+
             if (!savedFile && targetFile.exists()) {
                 targetFile.delete();
             }

--- a/sample_client/src/main/res/layout/main.xml
+++ b/sample_client/src/main/res/layout/main.xml
@@ -7,6 +7,8 @@
  ~ SPDX-License-Identifier: MIT
 -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -60,7 +62,130 @@
         android:layout_height="@dimen/frame_height"
         android:layout_alignParentLeft="true"
         android:layout_alignParentRight="true"
-        android:layout_above="@+id/button_download"></FrameLayout>
+        android:layout_above="@+id/button_download">
+
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <LinearLayout
+                android:orientation="vertical"
+                android:layout_gravity="center_vertical"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content">
+
+                <Button
+                    android:id="@+id/button_speed_test"
+                    style="@style/ButtonStyle"
+                    android:text="Speed test"
+                    android:layout_gravity="center"
+                    android:onClick="onClickHandler" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:orientation="horizontal"
+                android:weightSum="2"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+                <LinearLayout
+                    android:id="@+id/layout_upload_section"
+                    android:orientation="vertical"
+                    android:layout_gravity="center_vertical"
+                    android:layout_weight="1"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content">
+
+                    <TextView
+                        android:id="@+id/text_upload_label"
+                        style="@style/ProgressStyle"
+                        android:gravity="center"
+                        android:textSize="14sp"
+                        android:text="Upload"
+                        android:layout_height="wrap_content"
+                        android:layout_width="wrap_content" />
+
+                    <TextView
+                        android:id="@+id/text_upload_completion"
+                        style="@style/ProgressStyle"
+                        android:gravity="center"
+                        android:textSize="14sp"
+                        android:text="0%"
+                        android:layout_height="wrap_content"
+                        android:layout_width="wrap_content" />
+
+                    <TextView
+                        android:id="@+id/text_upload_speed"
+                        style="@style/ProgressStyle"
+                        android:gravity="center"
+                        android:textSize="14sp"
+                        android:text="0 kBps"
+                        android:layout_height="wrap_content"
+                        android:layout_width="wrap_content" />
+
+                    <TextView
+                        android:id="@+id/text_upload_elapsed"
+                        style="@style/ProgressStyle"
+                        android:gravity="center"
+                        android:textSize="14sp"
+                        android:text="0 ms"
+                        android:layout_height="wrap_content"
+                        android:layout_width="wrap_content" />
+
+                </LinearLayout>
+
+                <LinearLayout
+                    android:id="@+id/layout_download_section"
+                    android:orientation="vertical"
+                    android:layout_gravity="right|center_vertical|end"
+                    android:layout_weight="1"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content">
+
+                    <TextView
+                        android:id="@+id/text_download_label"
+                        style="@style/ProgressStyle"
+                        android:gravity="center"
+                        android:textSize="14sp"
+                        android:text="Download"
+                        android:layout_height="wrap_content"
+                        android:layout_width="wrap_content" />
+
+                    <TextView
+                        android:id="@+id/text_download_completion"
+                        style="@style/ProgressStyle"
+                        android:gravity="center"
+                        android:textSize="14sp"
+                        android:text="0%"
+                        android:layout_height="wrap_content"
+                        android:layout_width="wrap_content" />
+
+                    <TextView
+                        android:id="@+id/text_download_speed"
+                        style="@style/ProgressStyle"
+                        android:gravity="center"
+                        android:textSize="14sp"
+                        android:text="0 kBps"
+                        android:layout_height="wrap_content"
+                        android:layout_width="wrap_content" />
+
+                    <TextView
+                        android:id="@+id/text_download_elapsed"
+                        style="@style/ProgressStyle"
+                        android:gravity="center"
+                        android:textSize="14sp"
+                        android:text="0 ms"
+                        android:layout_height="wrap_content"
+                        android:layout_width="wrap_content" />
+
+                </LinearLayout>
+
+            </LinearLayout>
+
+        </LinearLayout>
+
+    </FrameLayout>
 
     <Button
         android:id="@id/button_download"


### PR DESCRIPTION
## What:

The Nextcloud Android client does not currently feature any way to limit bandwidth of the auto upload feature like the desktop client [does](https://github.com/nextcloud/android/issues/1662). To add this feature this library would need to offer an API to limit the download and upload speed.

## Why:

A client side limit is useful for cases where network bandwidth is limited and where the router the client is using is not smart enough to throttle invididual devices and insteads results in the entire network hanging (don't ask me how I know :P).

## How:

This PR replaces the buffered input and output streams in [DownloadFileRemoteOperation](https://github.com/nextcloud/android-library/blob/17a65c2e37de96c31b4a92c8ff7d0dee1010a1e5/library/src/main/java/com/owncloud/android/lib/resources/files/DownloadFileRemoteOperation.java#L85-L173) and [FileRequestEntity](https://github.com/nextcloud/android-library/blob/17a65c2e37de96c31b4a92c8ff7d0dee1010a1e5/library/src/main/java/com/owncloud/android/lib/common/network/FileRequestEntity.java#L82-L132) with sources and sinks from okio which is a part of okhttp which is already included in the dependancies and then using a [Throttler](https://square.github.io/okio/3.x/okio/okio/okio/-throttler/index.html) also from okio to then limit bandwidth. I dont know if this is the best approach and im not all that familiar with buffers and the like in Java. This PR also modifies the example app to demonstrate that the limit works and does not impact performance too badly, I ran some basic tests by uploading and downloading files using the sample client and on my setup upload and download speeds were within 5% of the original speed.

I have left in the comments and testing results for now but ill remove those later once everone is happy.

Related issue [here](https://github.com/nextcloud/android-library/issues/1419).