### PR TITLE
BugFix - DNSCache Lock

### DIFF
--- a/library/src/main/java/com/nextcloud/common/DNSCache.kt
+++ b/library/src/main/java/com/nextcloud/common/DNSCache.kt
@@ -72,18 +72,22 @@ object DNSCache {
     /**
      * Set IP version preference for a hostname, and re-sort addresses if needed
      */
-    @RequiresApi(Build.VERSION_CODES.N)
     @JvmStatic
     fun setIPVersionPreference(
         hostname: String,
         preferIPV4: Boolean
     ) {
-        cache.compute(hostname) { _, old ->
-            val addresses =
-                old?.addresses?.let {
-                    sortAddresses(it, preferIPV4)
-                } ?: emptyList()
-            DNSInfo(addresses, preferIPV4)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            cache.compute(hostname) { _, old ->
+                val addresses =
+                    old?.addresses?.let {
+                        sortAddresses(it, preferIPV4)
+                    } ?: emptyList()
+                DNSInfo(addresses, preferIPV4)
+            }
+        } else {
+            val addresses = cache[hostname]?.addresses?.let { sortAddresses(it, preferIPV4) } ?: emptyList()
+            cache[hostname] = DNSInfo(addresses, preferIPV4)
         }
     }
 

--- a/library/src/main/java/com/nextcloud/common/DNSCache.kt
+++ b/library/src/main/java/com/nextcloud/common/DNSCache.kt
@@ -9,7 +9,6 @@
 package com.nextcloud.common
 
 import android.os.Build
-import androidx.annotation.RequiresApi
 import androidx.annotation.VisibleForTesting
 import com.nextcloud.android.lib.core.Clock
 import com.nextcloud.android.lib.core.ClockImpl


### PR DESCRIPTION
### Issue

`DNSCache` used `@Synchronized` on all public methods to protect access to a `MutableMap`.

All threads must acquire the lock, even for read operations like `isIPV6First()` or `lookup()`

Methods like `lookup()` perform DNS resolution, which can be slow. Holding the `@Synchronized` lock this increases the risk of blocking critical threads like the UI or [Android system event receivers.](https://github.com/nextcloud/android/pull/15159)

### Changes

Replaced `MutableMap` with `ConcurrentHashMap` to enable lock-free concurrent access.
Removed unnecessary `@Synchronized` annotations from all methods.
Use`ConcurrentHashMap.compute()`, ensuring atomic read–modify–write operations **without external locking.**

### Issue Logs

```
Logs:
"main" tid=1 Blocked
 at com.nextcloud.common.DNSCache.clear (unavailable:2)
 at [com.owncloud.android](http://com.owncloud.android/).utils.ReceiversHelper$1.onReceive ([ReceiversHelper.java:49](http://receivershelper.java:49/))
 at [android.app](http://android.app/).LoadedApk$ReceiverDispatcher$Args.lambda$getRunnable$0 ([LoadedApk.java:1821](http://loadedapk.java:1821/))
 at [android.app](http://android.app/).LoadedApk$ReceiverDispatcher$Args.$r8$lambda$gDuJqgxY6Zb-ifyeubKeivTLAwk (unavailable)
 at [android.app](http://android.app/).LoadedApk$ReceiverDispatcher$Args$$ExternalSyntheticLambda0.run (unavailable:2)
 at android.os.Handler.handleCallback ([Handler.java:1000](http://handler.java:1000/))
 at android.os.Handler.dispatchMessage ([Handler.java:104](http://handler.java:104/))
 at android.os.Looper.loopOnce ([Looper.java:242](http://looper.java:242/))
 at android.os.Looper.loop ([Looper.java:362](http://looper.java:362/))
 at [android.app](http://android.app/).ActivityThread.main ([ActivityThread.java:8393](http://activitythread.java:8393/))
 at java.lang.reflect.Method.invoke (Native method)
 at [com.android](http://com.android/).internal.os.RuntimeInit$MethodAndArgsCaller.run ([RuntimeInit.java:552](http://runtimeinit.java:552/))
 at [com.android](http://com.android/).internal.os.ZygoteInit.main ([ZygoteInit.java:992](http://zygoteinit.java:992/))

"androidx.work-3" tid=41 Native
 #00  pc 0x00000000000ec824  /apex/com.android.runtime/lib64/bionic/libc.so (read+4)
 #01  pc 0x00000000000f8990  /apex/com.android.runtime/lib64/bionic/libc.so (__sread+48)
 #02  pc 0x00000000000f887c  /apex/com.android.runtime/lib64/bionic/libc.so (__srefill+268)

"ReferenceQueueDaemon" tid=6 Waiting
 at java.lang.Object.wait (Native method)
 at java.lang.Object.wait ([Object.java:405](http://object.java:405/))

"FinalizerDaemon" tid=7 Waiting
 at java.lang.Object.wait (Native method)
 at java.lang.Object.wait ([Object.java:405](http://object.java:405/))

"MultiThreadedHttpConnectionManager cleanup" tid=51 Waiting
 at java.lang.Object.wait (Native method)

"androidx.work-1" tid=38 Waiting
 at jdk.internal.misc.Unsafe.park (Native method)
 at java.util.concurrent.locks.LockSupport.park ([LockSupport.java:341](http://locksupport.java:341/))
 at java.lang.Object.wait ([Object.java:405](http://object.java:405/))

...
```