### PR TITLE
Remove bogus HTTP header

### DIFF
--- a/library/src/main/java/com/nextcloud/common/OkHttpMethodBase.kt
+++ b/library/src/main/java/com/nextcloud/common/OkHttpMethodBase.kt
@@ -41,10 +41,6 @@ abstract class OkHttpMethodBase(
     private val requestBuilder: Request.Builder = Request.Builder()
     private var request: Request? = null
 
-    init {
-        requestHeaders["http.protocol.single-cookie-header"] = "true"
-    }
-
     @Throws(IllegalStateException::class)
     private fun buildQueryParameter(): HttpUrl {
         val httpBuilder =


### PR DESCRIPTION
This is not a real HTTP header and it triggers error logs in reverse proxies:

```
2026/04/18 12:02:20 [info] 478#478: *312510 client sent invalid header line: "http.protocol.single-cookie-header: true" while reading client request headers, client: (...), server: (...) request: "GET /ocs/v2.php/cloud/user?format=json HTTP/1.1"
```

I suspect this was accidentally ported from the Java code, where that flag is a *parameter* for the HTTP client, not an HTTP header. This goes all the way back to 52894c1bd25.