### PR TITLE
fix(chunk-file-request): array index out of bound exception

### DIFF
--- a/library/src/main/java/com/owncloud/android/lib/common/network/ChunkFromFileChannelRequestEntity.java
+++ b/library/src/main/java/com/owncloud/android/lib/common/network/ChunkFromFileChannelRequestEntity.java
@@ -1,7 +1,8 @@
 /*
  * Nextcloud Android Library
  *
- * SPDX-FileCopyrightText: 2018-2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2018-2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2026 Alper Ozturk <alper.ozturk@nextcloud.com>
  * SPDX-FileCopyrightText: 2018-2019 Tobias Kaminsky <tobias@kaminsky.me>
  * SPDX-FileCopyrightText: 2014-2015 ownCloud Inc.
  * SPDX-FileCopyrightText: 2014 David A. Velasco <dvelasco@solidgear.es>
@@ -20,7 +21,6 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Set;
 
 
@@ -37,7 +37,6 @@ public class ChunkFromFileChannelRequestEntity implements RequestEntity, Progres
     private long mOffset;
     private long mTransferred;
     private final Set<OnDatatransferProgressListener> mDataTransferListeners = new HashSet<>();
-    private ByteBuffer mBuffer = ByteBuffer.allocate(4096);
 
     public ChunkFromFileChannelRequestEntity(final FileChannel channel, final String contentType, long offset, 
                                              long chunkSize, final File file) {
@@ -94,52 +93,50 @@ public class ChunkFromFileChannelRequestEntity implements RequestEntity, Progres
     }
 
     public void writeRequest(final OutputStream out) throws IOException {
-        int readCount;
-        Iterator<OnDatatransferProgressListener> progressListenerIterator;
+        mChannel.position(mOffset);
+        long maxCount = Math.min(mOffset + length, mChannel.size());
+        long remaining = maxCount - mOffset;
 
-        try {
-            mChannel.position(mOffset);
-            long size = mFile.length();
-            if (size == 0) {
-                size = -1;
-            }
-            long maxCount = Math.min(mOffset + length, mChannel.size());
-            while (mChannel.position() < maxCount) {
-                readCount = mChannel.read(mBuffer);
-                try {
-                    out.write(mBuffer.array(), 0, readCount);
-                } catch (IOException io) {
-                    // work-around try catch to filter exception in writing
-                    throw new FileRequestEntity.WriteException(io);
-                }
-                mBuffer.clear();
-                if (mTransferred < maxCount) {  // condition to avoid accumulate progress for repeated chunks
-                    mTransferred += readCount;
-                }
-                synchronized (mDataTransferListeners) {
-                    progressListenerIterator = mDataTransferListeners.iterator();
+        long rawSize = mFile.length();
+        long fileSize = rawSize > 0 ? rawSize : -1;
 
-                    while (progressListenerIterator.hasNext()) {
-                        progressListenerIterator.next().onTransferProgress(readCount, mTransferred, size, 
-                                                                           mFile.getAbsolutePath());
-                    }
-                }
-            }
+        byte[] buffer = new byte[4096];
+        ByteBuffer byteBuffer = ByteBuffer.wrap(buffer);
 
-        } catch (IOException io) {
-            // any read problem will be handled as if the file is not there
-            if (io instanceof FileNotFoundException) {
-                throw io;
-            } else {
+        while (remaining > 0) {
+            int toRead = (int) Math.min(buffer.length, remaining);
+            int bytesRead;
+
+            byteBuffer.position(0);
+            byteBuffer.limit(toRead);
+
+            try {
+                bytesRead = mChannel.read(byteBuffer);
+            } catch (IOException e) {
                 FileNotFoundException fnf = new FileNotFoundException("Exception reading source file");
-                fnf.initCause(io);
+                fnf.initCause(e);
                 throw fnf;
             }
 
-        } catch (FileRequestEntity.WriteException we) {
-            throw we.getWrapped();
+            if (bytesRead <= 0) {
+                break;
+            }
+
+            out.write(buffer, 0, bytesRead);
+            remaining -= bytesRead;
+
+            if (mTransferred < maxCount) {
+                mTransferred += bytesRead;
+            }
+            notifyTransferProgress(bytesRead, fileSize);
         }
-            
     }
 
+    private void notifyTransferProgress(int bytesRead, long fileSize) {
+        synchronized (mDataTransferListeners) {
+            for (OnDatatransferProgressListener listener : mDataTransferListeners) {
+                listener.onTransferProgress(bytesRead, mTransferred, fileSize, mFile.getAbsolutePath());
+            }
+        }
+    }
 }


### PR DESCRIPTION
Client PR: https://github.com/nextcloud/android/pull/17191

Tested with 1GB file and app was able to successfully upload on same instance that gives error below

### Issue

`ChunkFromFileChannelRequestEntity` created from `ChunkedFileUploadRemoteOperation` via channel and chunk.

Channel and chunk values may cause the following exception thus root cause of it can be from whether loop logic in `ChunkFromFileChannelRequestEntity` or creation logic from `ChunkedFileUploadRemoteOperation`.

```
java.lang.ArrayIndexOutOfBoundsException:
src.length=4096, srcPos=0,
dst.length=2048, dstPos=0,
length=-1
```

#### Exception

```
05-08 22:10:20.370 14592 14618 E UploadFileOperation:
Upload of
/storage/emulated/0/Android/media/com.t_example.android.webdav/
com.t_example.android.webdav/tmp/120049010000000300218142@example.com/
A090125/1GB.bin
to
/A090125/1GB.bin

Unexpected exception:

java.lang.ArrayIndexOutOfBoundsException:
src.length=4096, srcPos=0,
dst.length=2048, dstPos=0,
length=-1

Stack trace:
    at java.lang.System.arraycopy(System.java:528)
    at java.io.BufferedOutputStream.write(BufferedOutputStream.java:128)
    at com.owncloud.android.lib.common.network.ChunkFromFileChannelRequestEntity.writeRequest(ChunkFromFileChannelRequestEntity.java:110)
    at org.apache.commons.httpclient.methods.EntityEnclosingMethod.writeRequestBody(EntityEnclosingMethod.java:499)
    at org.apache.commons.httpclient.HttpMethodBase.writeRequest(HttpMethodBase.java:2114)
    at org.apache.commons.httpclient.HttpMethodBase.execute(HttpMethodBase.java:1096)
    at org.apache.commons.httpclient.HttpMethodDirector.executeWithRetry(HttpMethodDirector.java:398)
    at org.apache.commons.httpclient.HttpMethodDirector.executeMethod(HttpMethodDirector.java:171)
    at org.apache.commons.httpclient.HttpClient.executeMethod(HttpClient.java:397)
    at org.apache.commons.httpclient.HttpClient.executeMethod(HttpClient.java:323)
    at com.owncloud.android.lib.common.OwnCloudClient.executeMethod(OwnCloudClient.java:192)
    at com.owncloud.android.lib.resources.files.ChunkedFileUploadRemoteOperation.uploadChunk(ChunkedFileUploadRemoteOperation.java:294)
    at com.owncloud.android.lib.resources.files.ChunkedFileUploadRemoteOperation.run(ChunkedFileUploadRemoteOperation.java:201)
    at com.owncloud.android.lib.common.operations.RemoteOperation.execute(RemoteOperation.java:193)
    at com.owncloud.android.operations.UploadFileOperation.normalUpload(UploadFileOperation.java:1162)
    at com.owncloud.android.operations.UploadFileOperation.run(UploadFileOperation.java:503)
    at com.owncloud.android.lib.common.operations.RemoteOperation.execute(RemoteOperation.java:193)
    at com.nextcloud.client.jobs.upload.FileUploadWorker$upload$2.invokeSuspend(FileUploadWorker.kt:363)
    at com.nextcloud.client.jobs.upload.FileUploadWorker$upload$2.invoke(Unknown Source:8)
    at com.nextcloud.client.jobs.upload.FileUploadWorker$upload$2.invoke(Unknown Source:4)
    at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:42)
    at kotlinx.coroutines.BuildersKt__Builders_commonKt.withContext(Builders.common.kt:164)
    at kotlinx.coroutines.BuildersKt.withContext(Unknown Source:1)
    at com.nextcloud.client.jobs.upload.FileUploadWorker.upload(FileUploadWorker.kt:358)
    at com.nextcloud.client.jobs.upload.FileUploadWorker.access$upload(FileUploadWorker.kt:56)
    at com.nextcloud.client.jobs.upload.FileUploadWorker$uploadFiles$2$result$1.invokeSuspend(FileUploadWorker.kt:287)
    at com.nextcloud.client.jobs.upload.FileUploadWorker$uploadFiles$2$result$1.invoke(Unknown Source:8)
    at com.nextcloud.client.jobs.upload.FileUploadWorker$uploadFiles$2$result$1.invoke(Unknown Source:4)
    at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:42)
    at kotlinx.coroutines.BuildersKt__Builders_commonKt.withContext(Builders.common.kt:164)
    at kotlinx.coroutines.BuildersKt.withContext(Unknown Source:1)
```

### Changes

- Reverses while loop condition to better readability (remaning = max count - chunk start)
- Checks channel read and exit if invalid
- Removes iterator