### PR TITLE
chore(sdk): min version 26

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -143,7 +143,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 23
+        minSdkVersion 26
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArgument "TEST_SERVER_URL", "${NC_TEST_SERVER_BASEURL}"

--- a/library/src/androidTest/java/com/owncloud/android/lib/resources/files/UploadFileRemoteOperationIT.kt
+++ b/library/src/androidTest/java/com/owncloud/android/lib/resources/files/UploadFileRemoteOperationIT.kt
@@ -7,7 +7,6 @@
  */
 package com.owncloud.android.lib.resources.files
 
-import android.os.Build
 import com.owncloud.android.AbstractIT
 import com.owncloud.android.lib.common.utils.Log_OC
 import com.owncloud.android.lib.resources.files.model.RemoteFile
@@ -80,24 +79,19 @@ class UploadFileRemoteOperationIT : AbstractIT() {
         )
     }
 
-    private fun getCreationTimestamp(file: File): Long? {
-        return if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-            return null
-        } else {
-            try {
-                Files
-                    .readAttributes(file.toPath(), BasicFileAttributes::class.java)
-                    .creationTime()
-                    .to(TimeUnit.SECONDS)
-            } catch (e: IOException) {
-                Log_OC.e(
-                    UploadFileRemoteOperation::class.java.simpleName,
-                    "Failed to read creation timestamp for file: " + file.name
-                )
-                null
-            }
+    private fun getCreationTimestamp(file: File): Long? =
+        try {
+            Files
+                .readAttributes(file.toPath(), BasicFileAttributes::class.java)
+                .creationTime()
+                .to(TimeUnit.SECONDS)
+        } catch (e: IOException) {
+            Log_OC.e(
+                UploadFileRemoteOperation::class.java.simpleName,
+                "Failed to read creation timestamp for file: " + file.name
+            )
+            null
         }
-    }
 
     companion object {
         const val TIME_OFFSET = 10

--- a/library/src/main/java/com/nextcloud/common/DNSCache.kt
+++ b/library/src/main/java/com/nextcloud/common/DNSCache.kt
@@ -8,7 +8,6 @@
  */
 package com.nextcloud.common
 
-import android.os.Build
 import androidx.annotation.VisibleForTesting
 import com.nextcloud.android.lib.core.Clock
 import com.nextcloud.android.lib.core.ClockImpl
@@ -76,17 +75,12 @@ object DNSCache {
         hostname: String,
         preferIPV4: Boolean
     ) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            cache.compute(hostname) { _, old ->
-                val addresses =
-                    old?.addresses?.let {
-                        sortAddresses(it, preferIPV4)
-                    } ?: emptyList()
-                DNSInfo(addresses, preferIPV4)
-            }
-        } else {
-            val addresses = cache[hostname]?.addresses?.let { sortAddresses(it, preferIPV4) } ?: emptyList()
-            cache[hostname] = DNSInfo(addresses, preferIPV4)
+        cache.compute(hostname) { _, old ->
+            val addresses =
+                old?.addresses?.let {
+                    sortAddresses(it, preferIPV4)
+                } ?: emptyList()
+            DNSInfo(addresses, preferIPV4)
         }
     }
 

--- a/library/src/main/java/com/owncloud/android/lib/common/network/AdvancedSslSocketFactory.java
+++ b/library/src/main/java/com/owncloud/android/lib/common/network/AdvancedSslSocketFactory.java
@@ -89,14 +89,12 @@ public class AdvancedSslSocketFactory implements SecureProtocolSocketFactory {
 
     /*
     private void logSslInfo() {
-    	if (Build.VERSION.SDK_INT > Build.VERSION_CODES.FROYO) {
-	    	Log_OC.v(TAG, "SUPPORTED SSL PARAMETERS");
-	    	logSslParameters(mSslContext.getSupportedSSLParameters());
-	    	Log_OC.v(TAG, "DEFAULT SSL PARAMETERS");
-	    	logSslParameters(mSslContext.getDefaultSSLParameters());
-	    	Log_OC.i(TAG, "CURRENT PARAMETERS");
-	    	Log_OC.i(TAG, "Protocol: " + mSslContext.getProtocol());
-    	}
+    	Log_OC.v(TAG, "SUPPORTED SSL PARAMETERS");
+	    logSslParameters(mSslContext.getSupportedSSLParameters());
+	    Log_OC.v(TAG, "DEFAULT SSL PARAMETERS");
+	    logSslParameters(mSslContext.getDefaultSSLParameters());
+	    Log_OC.i(TAG, "CURRENT PARAMETERS");
+	    Log_OC.i(TAG, "Protocol: " + mSslContext.getProtocol());
     	Log_OC.i(TAG, "PROVIDER");
     	logSecurityProvider(mSslContext.getProvider());
 	}

--- a/library/src/main/java/com/owncloud/android/lib/common/network/AdvancedX509KeyManager.java
+++ b/library/src/main/java/com/owncloud/android/lib/common/network/AdvancedX509KeyManager.java
@@ -19,7 +19,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.Uri;
-import android.os.Build;
 import android.security.KeyChain;
 import android.security.KeyChainException;
 import android.util.SparseArray;
@@ -514,13 +513,11 @@ public class AdvancedX509KeyManager
        flags |= PendingIntent.FLAG_IMMUTABLE;
        final PendingIntent call = PendingIntent.getActivity(context, 0, intent, flags);
        NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
-       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-           NotificationChannel channel = new NotificationChannel(
-               NOTIFICATION_CHANNEL_ID,
-               context.getString(R.string.notification_channel_name),
-               NotificationManager.IMPORTANCE_DEFAULT);
-           notificationManager.createNotificationChannel(channel);
-       }
+       NotificationChannel channel = new NotificationChannel(
+           NOTIFICATION_CHANNEL_ID,
+           context.getString(R.string.notification_channel_name),
+           NotificationManager.IMPORTANCE_DEFAULT);
+       notificationManager.createNotificationChannel(channel);
        final Notification notification = new NotificationCompat
            .Builder(context, NOTIFICATION_CHANNEL_ID)
            .setContentTitle(context.getString(R.string.notification_title_select_client_cert))

--- a/library/src/main/java/com/owncloud/android/lib/resources/assistant/chat/model/Conversation.kt
+++ b/library/src/main/java/com/owncloud/android/lib/resources/assistant/chat/model/Conversation.kt
@@ -8,8 +8,6 @@
 
 package com.owncloud.android.lib.resources.assistant.chat.model
 
-import android.os.Build
-import androidx.annotation.RequiresApi
 import com.google.gson.annotations.SerializedName
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -34,9 +32,8 @@ data class Conversation(
     }
 
     @OptIn(ExperimentalTime::class)
-    @RequiresApi(Build.VERSION_CODES.O)
-    fun titleRepresentation(): String {
-        return if (title != null) {
+    fun titleRepresentation(): String =
+        if (title != null) {
             title
         } else {
             val instant = Instant.fromEpochSeconds(timestamp)
@@ -47,7 +44,6 @@ data class Conversation(
                     .ofPattern(TITLE_PRESENTATION_TIME_PATTERN, Locale.getDefault())
                     .withZone(deviceZone)
 
-            return formatter.format(instant.toJavaInstant())
+            formatter.format(instant.toJavaInstant())
         }
-    }
 }

--- a/library/src/main/java/com/owncloud/android/lib/resources/files/DownloadFileRemoteOperation.kt
+++ b/library/src/main/java/com/owncloud/android/lib/resources/files/DownloadFileRemoteOperation.kt
@@ -6,8 +6,6 @@
  */
 package com.owncloud.android.lib.resources.files
 
-import android.os.Build
-import androidx.annotation.RequiresApi
 import com.nextcloud.common.NextcloudClient
 import com.nextcloud.common.SessionTimeOut
 import com.nextcloud.common.defaultSessionTimeOut
@@ -28,7 +26,6 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
 
 @Suppress("NestedBlockDepth", "TooGenericExceptionCaught", "ThrowsCount")
-@RequiresApi(Build.VERSION_CODES.O)
 class DownloadFileRemoteOperation
     @JvmOverloads
     constructor(

--- a/sample_client/build.gradle
+++ b/sample_client/build.gradle
@@ -38,7 +38,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 23
+        minSdkVersion 26
         targetSdkVersion 36
 
         multiDexEnabled = true

--- a/sample_client/src/main/java/com/owncloud/android/lib/sampleclient/MainActivity.java
+++ b/sample_client/src/main/java/com/owncloud/android/lib/sampleclient/MainActivity.java
@@ -23,8 +23,6 @@ import android.widget.ListView;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import androidx.annotation.RequiresApi;
-
 import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.common.OwnCloudClientFactory;
 import com.owncloud.android.lib.common.OwnCloudCredentialsFactory;
@@ -129,9 +127,7 @@ public class MainActivity extends Activity implements OnRemoteOperationListener,
                 startRemoteDeletion();
                 break;
             case R.id.button_download:
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    startDownload();
-                }
+                startDownload();
                 break;
             case R.id.button_delete_local:
                 startLocalDeletion();
@@ -174,7 +170,6 @@ public class MainActivity extends Activity implements OnRemoteOperationListener,
         removeOperation.execute(mClient, this, mHandler);
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.O)
     private void startDownload() {
         File downFolder = new File(getCacheDir(), getString(R.string.download_folder_path));
         downFolder.mkdir();


### PR DESCRIPTION
### Reason

Use modern APIs to provide faster, safer, and more reliable networking for clients, while reducing maintenance overhead and avoiding duplicate code.

### Example

Using a `ConcurrentHashMap` instead of a `synchronized` block with `HashSet`.

### Changes

Min supported Android version is now 8.0.