### PR TITLE
fix(share): add missing password by talk in shares

### DIFF
--- a/library/src/main/java/com/owncloud/android/lib/resources/shares/CreateShareRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/shares/CreateShareRemoteOperation.java
@@ -38,6 +38,7 @@ public class CreateShareRemoteOperation extends RemoteOperation<List<OCShare>> {
     private static final String PARAM_PERMISSIONS = "permissions";
     private static final String PARAM_NOTE = "note";
     private static final String PARAM_ATTRIBUTES = "attributes";
+    private static final String PARAM_SEND_PASSWORD_BY_TALK = "sendPasswordByTalk";
 
     private final String remoteFilePath;
     private final ShareType shareType;
@@ -48,6 +49,7 @@ public class CreateShareRemoteOperation extends RemoteOperation<List<OCShare>> {
     private boolean getShareDetails;
     private String note;
     private String attributes;
+    private Boolean sendPasswordByTalk;
 
     /**
      * Constructor
@@ -134,6 +136,10 @@ public class CreateShareRemoteOperation extends RemoteOperation<List<OCShare>> {
         getShareDetails = set;
     }
 
+    public void setSendPasswordByTalk(Boolean sendPasswordByTalk) {
+        this.sendPasswordByTalk = sendPasswordByTalk;
+    }
+
     @Override
     protected RemoteOperationResult<List<OCShare>> run(OwnCloudClient client) {
         RemoteOperationResult<List<OCShare>> result;
@@ -166,6 +172,10 @@ public class CreateShareRemoteOperation extends RemoteOperation<List<OCShare>> {
 
             if (!TextUtils.isEmpty(attributes)) {
                 post.addParameter(PARAM_ATTRIBUTES, attributes);
+            }
+
+            if (sendPasswordByTalk != null) {
+                post.addParameter(PARAM_SEND_PASSWORD_BY_TALK, Boolean.toString(sendPasswordByTalk));
             }
 
             post.addRequestHeader(OCS_API_HEADER, OCS_API_HEADER_VALUE);

--- a/library/src/main/java/com/owncloud/android/lib/resources/shares/OCShare.kt
+++ b/library/src/main/java/com/owncloud/android/lib/resources/shares/OCShare.kt
@@ -67,6 +67,7 @@ class OCShare :
         }
     var note: String? = null
     var isHideFileDownload = false
+    var isSendPasswordByTalk = false
     var label: String? = null
     var isHasPreview = false
     var mimetype: String? = null
@@ -110,6 +111,7 @@ class OCShare :
         isPasswordProtected = false
         note = ""
         isHideFileDownload = false
+        isSendPasswordByTalk = false
         label = ""
         isHasPreview = false
         mimetype = ""
@@ -152,6 +154,7 @@ class OCShare :
         isPasswordProtected = source.readInt() == 1
         note = source.readString()
         isHideFileDownload = source.readInt() == 1
+        isSendPasswordByTalk = source.readInt() == 1
         label = source.readString()
         isHasPreview = source.readInt() == 1
         mimetype = source.readString()
@@ -184,6 +187,7 @@ class OCShare :
         dest.writeInt(if (isPasswordProtected) 1 else 0)
         dest.writeString(note)
         dest.writeInt(if (isHideFileDownload) 1 else 0)
+        dest.writeInt(if (isSendPasswordByTalk) 1 else 0)
         dest.writeString(label)
         dest.writeInt(if (isHasPreview) 1 else 0)
         dest.writeString(mimetype)

--- a/library/src/main/java/com/owncloud/android/lib/resources/shares/ShareXMLParser.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/shares/ShareXMLParser.java
@@ -64,6 +64,7 @@ public class ShareXMLParser {
 	private static final String NODE_SHARE_WITH_DISPLAY_NAME = "share_with_displayname";
 	private static final String NODE_NOTE = "note";
 	private static final String NODE_HIDE_DOWNLOAD = "hide_download";
+	private static final String NODE_SEND_PASSWORD_BY_TALK = "send_password_by_talk";
 	private static final String NODE_UID_OWNER = "uid_owner";
 	private static final String NODE_LABEL = "label";
 	private static final String NODE_HAS_PREVIEW = "has_preview";
@@ -387,6 +388,11 @@ public class ShareXMLParser {
 				case NODE_HIDE_DOWNLOAD:
 					boolean b = TRUE.equalsIgnoreCase(readNode(parser, NODE_HIDE_DOWNLOAD));
 					share.setHideFileDownload(b);
+					break;
+
+				case NODE_SEND_PASSWORD_BY_TALK:
+					share.setSendPasswordByTalk(
+						TRUE.equalsIgnoreCase(readNode(parser, NODE_SEND_PASSWORD_BY_TALK)));
 					break;
 
 				case NODE_UID_OWNER:

--- a/library/src/main/java/com/owncloud/android/lib/resources/shares/UpdateShareRemoteOperation.java
+++ b/library/src/main/java/com/owncloud/android/lib/resources/shares/UpdateShareRemoteOperation.java
@@ -44,6 +44,7 @@ public class UpdateShareRemoteOperation extends RemoteOperation {
     private static final String PARAM_PERMISSIONS = "permissions";
     private static final String PARAM_NOTE = "note";
     private static final String PARAM_HIDE_DOWNLOAD = "hideDownload";
+    private static final String PARAM_SEND_PASSWORD_BY_TALK = "sendPasswordByTalk";
     private static final String PARAM_LABEL = "label";
     private static final String FORMAT_EXPIRATION_DATE = "yyyy-MM-dd";
     private static final String ENTITY_CONTENT_TYPE = "application/json";
@@ -74,6 +75,11 @@ public class UpdateShareRemoteOperation extends RemoteOperation {
      * Permission if file can be downloaded via share link (only for single file)
      */
     private Boolean hideFileDownload;
+
+    /**
+     * Enable or disable video verification via Nextcloud Talk before granting access to the share
+     */
+    private Boolean sendPasswordByTalk;
 
     private String note;
     private String label;
@@ -133,6 +139,10 @@ public class UpdateShareRemoteOperation extends RemoteOperation {
         this.hideFileDownload = hideFileDownload;
     }
 
+    public void setSendPasswordByTalk(Boolean sendPasswordByTalk) {
+        this.sendPasswordByTalk = sendPasswordByTalk;
+    }
+
     public void setLabel(String label) {
         this.label = label;
     }
@@ -169,6 +179,10 @@ public class UpdateShareRemoteOperation extends RemoteOperation {
 
         if (hideFileDownload != null) {
             params.addProperty(PARAM_HIDE_DOWNLOAD, Boolean.toString(hideFileDownload));
+        }
+
+        if (sendPasswordByTalk != null) {
+            params.addProperty(PARAM_SEND_PASSWORD_BY_TALK, Boolean.toString(sendPasswordByTalk));
         }
 
         if (note != null) {


### PR DESCRIPTION
- added missing send_password_by_talk boolean already present in nextcloud-server
- this PR is a dependency for an android app PR

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
