### PR TITLE
fix(webdav): handle weak and quoted gzip ETags

### DIFF
--- a/library/src/main/java/com/owncloud/android/lib/common/network/WebdavUtils.java
+++ b/library/src/main/java/com/owncloud/android/lib/common/network/WebdavUtils.java
@@ -256,34 +256,41 @@ public class WebdavUtils {
     }
 
     /**
+     * Normalizes an ETag.
      *
-     * @param rawEtag
-     * @return
+     * @param rawEtag the raw ETag value from the HTTP response
+     * @return the normalized ETag, or an empty string if {@code rawEtag} is
+     *         {@code null} or empty
      */
     public static String parseEtag(String rawEtag) {
-        if (rawEtag == null || rawEtag.length() == 0) {
+        if (rawEtag == null || rawEtag.isEmpty()) {
             return "";
         }
-        if (rawEtag.endsWith("-gzip")) {
-            rawEtag = rawEtag.substring(0, rawEtag.length() - 5);
+
+        // https://github.com/owncloud/client/issues/3946
+        if (rawEtag.startsWith("W/")) {
+            rawEtag = rawEtag.substring(2);
         }
+
+        // Remove any surrounding quotes.
         if (rawEtag.length() >= 2 && rawEtag.startsWith("\"") && rawEtag.endsWith("\"")) {
             rawEtag = rawEtag.substring(1, rawEtag.length() - 1);
         }
+
+        // https://github.com/owncloud/client/issues/1195
+        if (rawEtag.endsWith("-gzip")) {
+            rawEtag = rawEtag.substring(0, rawEtag.length() - 5);
+        }
+
         return rawEtag;
     }
 
     public static String getEtagFromResponse(HttpMethod method) {
         Header eTag = method.getResponseHeader("OC-ETag");
         if (eTag == null) {
-            eTag = method.getResponseHeader("oc-etag");
-        }
-        if (eTag == null) {
             eTag = method.getResponseHeader("ETag");
         }
-        if (eTag == null) {
-            eTag = method.getResponseHeader("etag");
-        }
+
         String result = "";
         if (eTag != null) {
             result = parseEtag(eTag.getValue());
@@ -294,14 +301,9 @@ public class WebdavUtils {
     public static String getEtagFromResponse(OkHttpMethodBase method) {
         String eTag = method.getResponseHeader("OC-ETag");
         if (eTag == null) {
-            eTag = method.getResponseHeader("oc-etag");
+            eTag = method.getResponseHeader("Etag");
         }
-        if (eTag == null) {
-            eTag = method.getResponseHeader("ETag");
-        }
-        if (eTag == null) {
-            eTag = method.getResponseHeader("etag");
-        }
+
         String result = "";
         if (eTag != null) {
             result = parseEtag(eTag);


### PR DESCRIPTION
## Summary

Better Android WebDAV ETag parsing with the desktop client's behavior.

The redundant lowercase response-header lookups were also removed because both underlying response APIs perform case-insensitive header-name matching.

Previously, `parseEtag()`:

- Removed `-gzip` only before removing surrounding quotes.
- Did not remove the weak ETag prefix (`W/`).
- Therefore failed to normalize values such as `W/"abc-gzip"`: the `-gzip` suffix was hidden behind the closing quote, and `W/` was retained.

This change normalizes ETags in the following order:

1. Remove the weak validator prefix (`W/`).
2. Remove surrounding double quotes.
3. Remove a trailing `-gzip` suffix.

Examples:

| Raw ETag | Before | After |
| --- | --- | --- |
| `W/"abc-gzip"` | `W/"abc-gzip"` | `abc` |
| `"abc-gzip"` | `abc-gzip` | `abc` |
| `"abc-gzip-value"` | `abc-gzip-value` | `abc-gzip-value` |
| `abc-gzip-gzip` | `abc-gzip` | `abc-gzip` |





## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
